### PR TITLE
fix(telegram): prevent unique constraint violation on relink

### DIFF
--- a/app/Telegram/TelegramWebhookHandler.php
+++ b/app/Telegram/TelegramWebhookHandler.php
@@ -76,6 +76,12 @@ final class TelegramWebhookHandler extends WebhookHandler
             ->where('is_active', true)
             ->update(['is_active' => false]);
 
+        UserTelegramChat::query()
+            ->where('user_id', $chat->user_id)
+            ->where('telegraph_chat_id', $this->chat->id)
+            ->where('id', '!=', $chat->id)
+            ->delete();
+
         $chat->update(['telegraph_chat_id' => $this->chat->id]);
         $chat->markAsLinked();
 

--- a/tests/Feature/TelegramWebhookDuplicateLinkTest.php
+++ b/tests/Feature/TelegramWebhookDuplicateLinkTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\UserTelegramChat;
+use DefStudio\Telegraph\Models\TelegraphBot;
+use DefStudio\Telegraph\Models\TelegraphChat;
+
+it('reproduces unique constraint violation when relinking telegram', function (): void {
+    $user = User::factory()->create();
+    $bot = TelegraphBot::factory()->create();
+
+    $telegraphChat = TelegraphChat::factory()->for($bot, 'bot')->create([
+        'chat_id' => '123456789',
+    ]);
+
+    $existingChat = UserTelegramChat::factory()->for($user)->create([
+        'telegraph_chat_id' => $telegraphChat->id,
+        'is_active' => true,
+        'linked_at' => now(),
+    ]);
+
+    $pendingChat = UserTelegramChat::factory()->for($user)->create([
+        'telegraph_chat_id' => null,
+        'is_active' => true,
+        'linking_token' => 'ABC123XY',
+        'token_expires_at' => now()->addHours(24),
+        'linked_at' => null,
+    ]);
+
+
+    expect(function () use ($pendingChat, $telegraphChat): void {
+        $pendingChat->update(['telegraph_chat_id' => $telegraphChat->id]);
+    })->toThrow(Illuminate\Database\UniqueConstraintViolationException::class);
+});
+
+it('prevents duplicate by deleting existing link before update', function (): void {
+    $user = User::factory()->create();
+    $bot = TelegraphBot::factory()->create();
+
+    $telegraphChat = TelegraphChat::factory()->for($bot, 'bot')->create([
+        'chat_id' => '123456789',
+    ]);
+
+    $existingChat = UserTelegramChat::factory()->for($user)->create([
+        'telegraph_chat_id' => $telegraphChat->id,
+        'is_active' => true,
+        'linked_at' => now(),
+    ]);
+
+    $pendingChat = UserTelegramChat::factory()->for($user)->create([
+        'telegraph_chat_id' => null,
+        'is_active' => true,
+        'linking_token' => 'ABC123XY',
+        'token_expires_at' => now()->addHours(24),
+        'linked_at' => null,
+    ]);
+
+    UserTelegramChat::query()
+        ->where('user_id', $user->id)
+        ->where('telegraph_chat_id', $telegraphChat->id)
+        ->where('id', '!=', $pendingChat->id)
+        ->delete();
+
+    $pendingChat->update(['telegraph_chat_id' => $telegraphChat->id]);
+
+    expect(UserTelegramChat::find($existingChat->id))->toBeNull();
+    expect($pendingChat->fresh()->telegraph_chat_id)->toBe($telegraphChat->id);
+});


### PR DESCRIPTION
When a user generates a new linking token and tries to link again, the code was only deactivating the old record but keeping it with the same telegraph_chat_id. This caused a unique constraint violation when updating the pending record with the same (user_id, telegraph_chat_id) combination.

The fix deletes any existing records for the user with the same telegraph_chat_id before linking the new one.

Fixes SQLSTATE[23505]: duplicate key value violates unique constraint "user_telegram_chats_user_id_telegraph_chat_id_unique"