### PR TITLE
fix: resolve N+1 query and correct test data structure in ChatController

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -19,7 +19,9 @@ final class ChatController
         Request $request,
         string $conversationId = ''
     ): \Inertia\Response {
-        $conversation = $conversationId !== '' ? Conversation::query()->find($conversationId) : null;
+        $conversation = $conversationId !== ''
+            ? Conversation::query()->with('messages')->find($conversationId)
+            : null;
 
         $messages = $conversation?->messages->map(fn (History $message): array => [
             'id' => $message->id,

--- a/tests/Feature/Controllers/ChatControllerTest.php
+++ b/tests/Feature/Controllers/ChatControllerTest.php
@@ -128,7 +128,7 @@ it('handles empty user message gracefully', function (): void {
     actingAs($user)
         ->post($url, [
             'messages' => [
-                ['role' => 'assistant', 'content' => 'Hello'], // No user message
+                ['role' => 'assistant', 'parts' => [['type' => 'text', 'text' => 'Hello']]],
             ],
         ])
         ->assertOk();


### PR DESCRIPTION
## Summary

- Fixed N+1 query issue in `ChatController::create()` by adding eager loading for `messages` relationship
- Fixed test data structure to use `'parts'` instead of `'content'` to match the actual API format
- All 6 ChatController tests pass