### PR TITLE
refactor: Rename AI agent and tool classes for clarity

### DIFF
--- a/app/Ai/Agents/MealPlanAgent.php
+++ b/app/Ai/Agents/MealPlanAgent.php
@@ -23,7 +23,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Workflow\WorkflowStub;
 
-final class MealPlanGeneratorAgent implements Agent, HasTools
+final class MealPlanAgent implements Agent, HasTools
 {
     use Promptable;
 

--- a/app/Ai/Agents/NutritionAdvisor.php
+++ b/app/Ai/Agents/NutritionAdvisor.php
@@ -6,10 +6,10 @@ namespace App\Ai\Agents;
 
 use App\Actions\GetUserProfileContextAction;
 use App\Ai\SystemPrompt;
-use App\Ai\Tools\GenerateMeal;
-use App\Ai\Tools\GenerateMealPlan;
+use App\Ai\Tools\CreateMealPlan;
 use App\Ai\Tools\GetUserProfile;
 use App\Ai\Tools\PredictGlucoseSpike;
+use App\Ai\Tools\SuggestSingleMeal;
 use App\Contracts\Ai\Advisor;
 use App\Enums\AgentMode;
 use App\Models\History;
@@ -28,9 +28,9 @@ final class NutritionAdvisor implements Advisor
     public function __construct(
         private User $user,
         private readonly GetUserProfileContextAction $profileContext,
-        private readonly GenerateMeal $generateMealTool,
+        private readonly SuggestSingleMeal $suggestSingleMealTool,
         private readonly GetUserProfile $getUserProfileTool,
-        private readonly GenerateMealPlan $generateMealPlanTool,
+        private readonly CreateMealPlan $createMealPlanTool,
         private readonly PredictGlucoseSpike $predictGlucoseSpikeTool,
     ) {}
 
@@ -74,9 +74,9 @@ final class NutritionAdvisor implements Advisor
     public function tools(): array
     {
         return [
-            $this->generateMealTool,
+            $this->suggestSingleMealTool,
             $this->getUserProfileTool,
-            $this->generateMealPlanTool,
+            $this->createMealPlanTool,
             $this->predictGlucoseSpikeTool,
         ];
     }
@@ -142,7 +142,7 @@ final class NutritionAdvisor implements Advisor
             'CHAT MODE: '.$this->mode->value,
         ];
 
-        if ($this->mode === AgentMode::GenerateMealPlan) {
+        if ($this->mode === AgentMode::CreateMealPlan) {
             $context[] = '';
             $context[] = 'The user has explicitly selected "Generate Meal Plan" mode. They want a complete multi-day meal plan.';
             $context[] = 'Use the generate_meal_plan tool to initiate the meal plan generation workflow.';

--- a/app/Ai/Agents/SingleMealAgent.php
+++ b/app/Ai/Agents/SingleMealAgent.php
@@ -11,7 +11,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 
-final class MealGeneratorAgent implements Agent, HasStructuredOutput
+final class SingleMealAgent implements Agent, HasStructuredOutput
 {
     use Promptable;
 

--- a/app/Ai/Tools/CreateMealPlan.php
+++ b/app/Ai/Tools/CreateMealPlan.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Ai\Agents\MealPlanGeneratorAgent;
+use App\Ai\Agents\MealPlanAgent;
 use App\Models\User;
 use Exception;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -12,11 +12,12 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 
-final readonly class GenerateMealPlan implements Tool
+final readonly class CreateMealPlan implements Tool
 {
     public function __construct(
-        private MealPlanGeneratorAgent $mealPlanGenerator,
-    ) {}
+        private MealPlanAgent $mealPlanAgent,
+    ) {
+    }
 
     /**
      * Get the description of the tool's purpose.
@@ -48,7 +49,7 @@ final readonly class GenerateMealPlan implements Tool
 
         try {
             // Start the meal plan generation workflow
-            $this->mealPlanGenerator->handle($user, $totalDays);
+            $this->mealPlanAgent->handle($user, $totalDays);
 
             return (string) json_encode([
                 'success' => true,

--- a/app/Ai/Tools/SuggestSingleMeal.php
+++ b/app/Ai/Tools/SuggestSingleMeal.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Ai\Agents\MealGeneratorAgent;
+use App\Ai\Agents\SingleMealAgent;
 use App\Models\User;
 use Exception;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -12,10 +12,10 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 
-final readonly class GenerateMeal implements Tool
+final readonly class SuggestSingleMeal implements Tool
 {
     public function __construct(
-        private MealGeneratorAgent $mealGenerator,
+        private SingleMealAgent $singleMealAgent,
     ) {}
 
     public function description(): string
@@ -44,7 +44,7 @@ final readonly class GenerateMeal implements Tool
         $specificRequest = $request['specific_request'] ?? null;
 
         try {
-            $meal = $this->mealGenerator->generate(
+            $meal = $this->singleMealAgent->generate(
                 $user,
                 $mealType,
                 $cuisine,

--- a/app/Enums/AgentMode.php
+++ b/app/Enums/AgentMode.php
@@ -7,5 +7,5 @@ namespace App\Enums;
 enum AgentMode: string
 {
     case Ask = 'ask';
-    case GenerateMealPlan = 'generate-meal-plan';
+    case CreateMealPlan = 'generate-meal-plan';
 }

--- a/app/Workflows/MealPlanDayGeneratorActivity.php
+++ b/app/Workflows/MealPlanDayGeneratorActivity.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Workflows;
 
-use App\Ai\Agents\MealPlanGeneratorAgent;
+use App\Ai\Agents\MealPlanAgent;
 use App\DataObjects\DayMealsData;
 use App\DataObjects\GlucoseAnalysis\GlucoseAnalysisData;
 use App\DataObjects\PreviousDayContext;
@@ -30,8 +30,8 @@ final class MealPlanDayGeneratorActivity extends Activity
         ?MealPlan $mealPlan = null,
         ?DietType $dietType = null,
     ): DayMealsData {
-        /** @var MealPlanGeneratorAgent $generateMealPlan */
-        $generateMealPlan = resolve(MealPlanGeneratorAgent::class);
+        /** @var MealPlanAgent $generateMealPlan */
+        $generateMealPlan = resolve(MealPlanAgent::class);
 
         if ($dietType instanceof DietType) {
             $generateMealPlan = $generateMealPlan->withDietType($dietType);

--- a/tests/Feature/Ai/Agents/MealPlanAgentTest.php
+++ b/tests/Feature/Ai/Agents/MealPlanAgentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Ai\Agents\MealPlanGeneratorAgent;
+use App\Ai\Agents\MealPlanAgent;
 use App\Enums\DietType;
 use App\Enums\GoalChoice;
 use App\Enums\MealPlanType;
@@ -14,21 +14,21 @@ use Workflow\WorkflowStub;
 uses(RefreshDatabase::class);
 
 it('returns fluent interface when setting diet type', function (): void {
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $result = $action->withDietType(DietType::Mediterranean);
 
-    expect($result)->toBeInstanceOf(MealPlanGeneratorAgent::class);
+    expect($result)->toBeInstanceOf(MealPlanAgent::class);
 });
 
 it('returns max tokens', function (): void {
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $maxTokens = $action->maxTokens();
 
     expect($maxTokens)->toBe(64000);
 });
 
 it('returns client options', function (): void {
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $options = $action->clientOptions();
 
     expect($options)->toBeArray()
@@ -83,9 +83,9 @@ it('generates a meal plan using Laravel AI SDK', function (): void {
         ],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $mealPlanData = $action->generate($user);
 
     expect($mealPlanData)
@@ -125,9 +125,9 @@ it('generates meal plan with minimal data', function (): void {
         'meals' => [],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $result = $action->generate($user);
 
     expect($result)->not->toBeNull();
@@ -147,7 +147,7 @@ it('starts workflow when handle is called', function (): void {
         'derived_activity_multiplier' => 1.5,
     ]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $action->handle($user);
 
     $mealPlan = $user->mealPlans()->first();
@@ -208,9 +208,9 @@ it('handles meals with no ingredients', function (): void {
         ],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $mealPlanData = $action->generate($user);
 
     expect($mealPlanData->meals)->toHaveCount(2);
@@ -241,9 +241,9 @@ it('works without file search store configured', function (): void {
         'meals' => [],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $mealPlanData = $action->generate($user);
 
     expect($mealPlanData)
@@ -275,9 +275,9 @@ it('uses file search store when configured', function (): void {
         'meals' => [],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $mealPlanData = $action->generate($user);
 
     expect($mealPlanData)
@@ -318,9 +318,9 @@ it('generates meals for a single day', function (): void {
         ],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $dayMeals = $action->generateForDay($user, 1, 7);
 
     expect($dayMeals)

--- a/tests/Feature/Workflows/MealPlanInitializeWorkflowTest.php
+++ b/tests/Feature/Workflows/MealPlanInitializeWorkflowTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Ai\Agents\MealPlanGeneratorAgent;
+use App\Ai\Agents\MealPlanAgent;
 use App\DataObjects\DayMealsData;
 use App\DataObjects\MealData;
 use App\DataObjects\PreviousDayContext;
@@ -163,10 +163,10 @@ it('generates day meals using activity with mocked agent', function (): void {
         ],
     ];
 
-    MealPlanGeneratorAgent::fake([$mockResponse]);
+    MealPlanAgent::fake([$mockResponse]);
 
     // Test using the action directly instead of activity instantiation
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $result = $action->generateForDay(
         $this->user,
         dayNumber: 1,
@@ -198,7 +198,7 @@ it('workflow class exists and extends correct base class', function (): void {
 it('workflow triggers via generate meal plan action with workflow stub fake', function (): void {
     Workflow\WorkflowStub::fake();
 
-    $action = resolve(MealPlanGeneratorAgent::class);
+    $action = resolve(MealPlanAgent::class);
     $action->handle($this->user);
 
     // Meal plan is now created synchronously before workflow starts

--- a/tests/Unit/Http/Requests/StoreAgentConversationRequestTest.php
+++ b/tests/Unit/Http/Requests/StoreAgentConversationRequestTest.php
@@ -119,10 +119,10 @@ it('ignores non-text parts when extracting user message', function () use ($crea
 it('extracts mode and model from request', function () use ($createRequest): void {
     $request = $createRequest([
         'messages' => [['role' => 'user', 'parts' => [['type' => 'text', 'text' => 'Hi']]]],
-        'mode' => AgentMode::GenerateMealPlan->value,
+        'mode' => AgentMode::CreateMealPlan->value,
         'model' => ModelName::GEMINI_2_5_FLASH->value,
     ]);
 
-    expect($request->mode())->toBe(AgentMode::GenerateMealPlan)
+    expect($request->mode())->toBe(AgentMode::CreateMealPlan)
         ->and($request->modelName())->toBe(ModelName::GEMINI_2_5_FLASH);
 });


### PR DESCRIPTION
## Summary
- Rename `GenerateMeal` → `SuggestSingleMeal` (Tool)
- Rename `GenerateMealPlan` → `CreateMealPlan` (Tool)
- Rename `MealGeneratorAgent` → `SingleMealAgent` (Agent)
- Rename `MealPlanGeneratorAgent` → `MealPlanAgent` (Agent)
- Rename `AgentMode::GenerateMealPlan` → `CreateMealPlan`