### PR TITLE
refactor: Extract head meta tags into reusable component

### DIFF
--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -24,7 +24,7 @@
     <meta name="keywords" content="@yield('meta_keywords')" />
 @else
     <meta name="keywords"
-        content="{{ $metaKeywords ?? 'diabetes nutrition, AI meal planner, glucose tracking, personalized meal plans, diabetes management' }}" />
+        content="{{ $metaKeywords ?? 'diabetes nutrition, AI meal planner, glucose tracking, personalized meal plans, diabetes management, blood sugar tracking, diabetic meal planning, AI nutrition assistant' }}" />
 @endif
 
 <link rel="canonical" href="@yield('canonical_url', strtok(url()->current(), '?'))" />
@@ -47,12 +47,12 @@
     <meta property="og:description" content="@yield('meta_description')" />
 @else
     <meta property="og:description"
-        content="{{ $metaDescription ?? 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels.' }}" />
+        content="{{ $metaDescription ?? 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels to achieve your health goals.' }}" />
 @endif
-<meta property="og:image" content="{{ asset('banner-acara-plate.webp') }}" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Acara Plate - AI Nutrition for Diabetes Management" />
+<meta property="og:image" content="@yield('og_image', asset('banner-acara-plate.webp'))" />
+<meta property="og:image:width" content="@yield('og_image_width', '1200')" />
+<meta property="og:image:height" content="@yield('og_image_height', '630')" />
+<meta property="og:image:alt" content="@yield('og_image_alt', 'Acara Plate - AI Nutrition for Diabetes Management')" />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
@@ -66,17 +66,21 @@
     <meta name="twitter:description" content="@yield('meta_description')" />
 @else
     <meta name="twitter:description"
-        content="{{ $metaDescription ?? 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels.' }}" />
+        content="{{ $metaDescription ?? 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels to achieve your health goals.' }}" />
 @endif
-<meta name="twitter:image" content="{{ asset('banner-acara-plate.webp') }}" />
-<meta name="twitter:image:alt" content="Acara Plate - AI Nutrition for Diabetes Management" />
+<meta name="twitter:image" content="@yield('og_image', asset('banner-acara-plate.webp'))" />
+<meta name="twitter:image:alt" content="@yield('og_image_alt', 'Acara Plate - AI Nutrition for Diabetes Management')" />
 
 <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any" />
 <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon/apple-touch-icon-180x180.png') }}" />
+<link rel="manifest" href="/build/manifest.webmanifest" />
+
+<link rel="preconnect" href="https://fonts.bunny.net">
+<link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
 @livewireStyles
 
-@vite(['resources/css/app.css', 'resources/js/app.js'])
+@vite(['resources/css/app.css'])
 
 @yield('head')
 @stack('head')
@@ -84,3 +88,5 @@
 @production
     <script defer src="https://cloud.umami.is/script.js" data-website-id="00659ffa-f13b-411a-81a7-76d2bd81d2c6"></script>
 @endproduction
+
+@stack('turnstile')

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1,49 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
     <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-
-        <title>@yield('title', 'Acara Plate - AI Diabetes Meal Planner & Glucose Tracker')</title>
-        <meta name="description" content="@yield('meta_description', 'Acara Plate is an AI-powered nutrition platform for diabetes management. Get personalized meal plans, track glucose levels, and achieve your health goals.')">
-        <meta name="keywords" content="@yield('meta_keywords', 'diabetes nutrition, AI meal planner, glucose tracking, personalized meal plans, diabetes management, blood sugar tracking, diabetic meal planning, AI nutrition assistant')">
-        <link rel="canonical" href="@yield('canonical_url', strtok(url()->current(), '?'))">
-        <meta name="robots" content="index, follow">
-        
-        <!-- Open Graph / Facebook -->
-        <meta property="og:type" content="website">
-        <meta property="og:url" content="{{ url()->current() }}">
-        <meta property="og:title" content="@yield('title', 'Acara Plate - AI Nutrition for Diabetes')">
-        <meta property="og:description" content="@yield('meta_description', 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels to achieve your health goals.')">
-        <meta property="og:image" content="@yield('og_image', asset('banner-acara-plate.webp'))">
-        <meta property="og:image:width" content="@yield('og_image_width', '1200')">
-        <meta property="og:image:height" content="@yield('og_image_height', '630')">
-        <meta property="og:image:alt" content="@yield('og_image_alt', 'Acara Plate - AI Nutrition for Diabetes Management')">
-        
-        <!-- Twitter -->
-        <meta name="twitter:card" content="summary_large_image">
-        <meta name="twitter:url" content="{{ url()->current() }}">
-        <meta name="twitter:title" content="@yield('title', 'Acara Plate - AI Nutrition for Diabetes')">
-        <meta name="twitter:description" content="@yield('meta_description', 'AI-powered nutrition platform for diabetes management. Get personalized meal plans and track glucose levels to achieve your health goals.')">
-        <meta name="twitter:image" content="@yield('og_image', asset('banner-acara-plate.webp'))">
-        <meta name="twitter:image:alt" content="@yield('og_image_alt', 'Acara Plate - AI Nutrition for Diabetes Management')">
-
-        <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any">
-        <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon/apple-touch-icon-180x180.png') }}">
-        <link rel="manifest" href="/build//manifest.webmanifest">
-
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
-
-        @production
-            <script defer src="https://cloud.umami.is/script.js" data-website-id="00659ffa-f13b-411a-81a7-76d2bd81d2c6"></script>
-        @endproduction
-
-        @vite(['resources/css/app.css'])
-
-        @livewireStyles
-
-        @yield('head')
+        @include('layouts.components.head')
     </head>
 
     <body>

--- a/resources/views/layouts/mini-app.blade.php
+++ b/resources/views/layouts/mini-app.blade.php
@@ -2,10 +2,6 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         @include('layouts.components.head')
-        @if (App::environment(['production', 'testing']))
-            <x-turnstile.scripts />
-        @endif
-        {{ $jsonLd ?? '' }}
     </head>
     <body>
         <livewire:flash-messages.show />

--- a/resources/views/pages/⚡snap-to-track.blade.php
+++ b/resources/views/pages/⚡snap-to-track.blade.php
@@ -99,6 +99,12 @@ class extends Component
     <x-json-ld.snap-to-track />
 </x-slot:jsonLd>
 
+@push('turnstile')
+    @if (App::environment(['production', 'testing']))
+        <x-turnstile.scripts />
+    @endif
+@endpush
+
 <div
     class="relative flex min-h-screen flex-col items-center overflow-hidden bg-linear-to-br from-slate-50 via-white to-blue-50 p-4 text-slate-900 lg:justify-center lg:p-8 dark:from-slate-950 dark:via-slate-900 dark:to-blue-950 dark:text-slate-50"
 >

--- a/resources/views/pages/⚡spike-calculator.blade.php
+++ b/resources/views/pages/⚡spike-calculator.blade.php
@@ -90,6 +90,12 @@ class extends Component
     <x-json-ld.spike-calculator />
 </x-slot:jsonLd>
 
+@push('turnstile')
+    @if (App::environment(['production', 'testing']))
+        <x-turnstile.scripts />
+    @endif
+@endpush
+
 <div
     class="relative flex min-h-screen flex-col items-center overflow-hidden bg-linear-to-br from-slate-50 via-white to-blue-50 p-4 text-slate-900 lg:justify-center lg:p-8 dark:from-slate-950 dark:via-slate-900 dark:to-blue-950 dark:text-slate-50"
 >


### PR DESCRIPTION
## Summary
- Extracted all SEO meta tags (title, description, og:image, twitter, etc.) into a reusable `layouts/components/head.blade.php`
- Refactored `default.blade.php` and `mini-app.blade.php` to use `@include('layouts.components.head')`
- Added `@stack('turnstile')` to load Turnstile scripts only on pages that need it
- Fixed duplicate Livewire JS loading that caused `$persist` property redefinition error
- Preserved backward compatibility with `@yield('head')` and `@stack('head')` for existing pages