### PR TITLE
fix: properly track user_id in ai_usages for Telegram and web

### DIFF
--- a/app/Listeners/TrackAiUsage.php
+++ b/app/Listeners/TrackAiUsage.php
@@ -68,6 +68,15 @@ final readonly class TrackAiUsage
     {
         try {
             $reflection = new ReflectionClass($agent);
+
+            if ($reflection->hasProperty('conversationUser')) {
+                $property = $reflection->getProperty('conversationUser');
+                $user = $property->getValue($agent);
+                if ($user instanceof User) {
+                    return $user;
+                }
+            }
+
             if ($reflection->hasProperty('user')) {
                 $property = $reflection->getProperty('user');
                 $user = $property->getValue($agent);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Cashier\Cashier;
 
 final class AppServiceProvider extends ServiceProvider
@@ -91,5 +92,6 @@ final class AppServiceProvider extends ServiceProvider
     private function registerEventListeners(): void
     {
         Event::listen(AgentPrompted::class, TrackAiUsage::class);
+        Event::listen(AgentStreamed::class, TrackAiUsage::class);
     }
 }

--- a/tests/Unit/Actions/ProcessAdvisorMessageActionTest.php
+++ b/tests/Unit/Actions/ProcessAdvisorMessageActionTest.php
@@ -58,7 +58,7 @@ it('creates new conversation when none exists', function (): void {
         $conversationStore,
     );
 
-    $user = User::factory()->make(['id' => 1]);
+    $user = User::factory()->create();
     $result = $action->handle($user, 'Test message');
 
     expect($result['response'])->toBe('Hello!');
@@ -74,7 +74,7 @@ it('uses existing conversation when provided', function (): void {
         resolve(ConversationStore::class),
     );
 
-    $user = User::factory()->make(['id' => 1]);
+    $user = User::factory()->create();
     $result = $action->handle($user, 'Another message', 'existing-conv');
 
     expect($result['response'])->toBe('Continuing...');
@@ -120,7 +120,7 @@ it('reuses latest conversation when no id provided but exists', function (): voi
         $conversationStore,
     );
 
-    $user = User::factory()->make(['id' => 1]);
+    $user = User::factory()->create();
     $result = $action->handle($user, 'Message');
 
     expect($result['response'])->toBe('Reusing!');
@@ -166,7 +166,7 @@ it('resets conversation', function (): void {
         $conversationStore,
     );
 
-    $user = User::factory()->make(['id' => 1]);
+    $user = User::factory()->create();
     $result = $action->resetConversation($user);
 
     expect($result)->toBe('new-conv');


### PR DESCRIPTION
## Summary

- Fixed Telegram bot storing `user_id` as null in `ai_usages` table by checking for `conversationUser` property first (set by the `continue()` method) before falling back to `user` property
- Fixed web ChatController not storing usage by adding explicit listener for `AgentStreamed` event in addition to `AgentPrompted`
- Updated tests to use `create()` instead of `make()` to properly persist user to database for foreign key constraint