### PR TITLE
feat(memory): add PullsConversationHistory contract + null fallback

### DIFF
--- a/.ai/guidelines/plate-core.blade.php
+++ b/.ai/guidelines/plate-core.blade.php
@@ -30,11 +30,17 @@ Memory contracts live in:
 
 - `app/Contracts/Memory/ManagesMemoryContext.php`
 - `app/Contracts/Memory/DispatchesMemoryExtraction.php`
+- `app/Contracts/Memory/PullsConversationHistory.php`
+
+Cross-boundary DTOs live in:
+
+- `app/Data/Memory/ConversationMessageData.php`
 
 Community-safe null implementations live in:
 
 - `app/Services/Memory/NullMemoryPromptContext.php`
 - `app/Services/Memory/NullMemoryExtractionDispatcher.php`
+- `app/Services/Memory/NullConversationHistoryPuller.php`
 
 Default bindings belong in `App\Providers\AppServiceProvider` using `bindIf()`. This lets the public app boot without `plate-core`, while the private package can override the bindings when installed.
 

--- a/app/Contracts/Memory/PullsConversationHistory.php
+++ b/app/Contracts/Memory/PullsConversationHistory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Memory;
+
+use App\Data\Memory\ConversationMessageData;
+use DateTimeInterface;
+use Illuminate\Support\Collection;
+
+interface PullsConversationHistory
+{
+    /**
+     * @return Collection<int, ConversationMessageData>
+     */
+    public function pendingMessagesFor(
+        int $userId,
+        ?DateTimeInterface $afterCreatedAt,
+        ?string $afterId,
+        int $limit,
+    ): Collection;
+
+    public function countPendingFor(
+        int $userId,
+        ?DateTimeInterface $afterCreatedAt,
+        ?string $afterId,
+    ): int;
+}

--- a/app/Data/Memory/ConversationMessageData.php
+++ b/app/Data/Memory/ConversationMessageData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Memory;
+
+use DateTimeInterface;
+use Spatie\LaravelData\Data;
+
+final class ConversationMessageData extends Data
+{
+    public function __construct(
+        public string $id,
+        public DateTimeInterface $createdAt,
+        public string $role,
+        public string $content,
+    ) {}
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,11 +6,13 @@ namespace App\Providers;
 
 use App\Contracts\Memory\DispatchesMemoryExtraction;
 use App\Contracts\Memory\ManagesMemoryContext;
+use App\Contracts\Memory\PullsConversationHistory;
 use App\Contracts\Services\IndexNowServiceContract;
 use App\Contracts\Services\StripeServiceContract;
 use App\Listeners\TrackAiUsage;
 use App\Models\User;
 use App\Services\IndexNowService;
+use App\Services\Memory\NullConversationHistoryPuller;
 use App\Services\Memory\NullMemoryExtractionDispatcher;
 use App\Services\Memory\NullMemoryPromptContext;
 use App\Services\StripeService;
@@ -35,6 +37,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->bind(IndexNowServiceContract::class, IndexNowService::class);
         $this->app->bindIf(ManagesMemoryContext::class, NullMemoryPromptContext::class);
         $this->app->bindIf(DispatchesMemoryExtraction::class, NullMemoryExtractionDispatcher::class);
+        $this->app->bindIf(PullsConversationHistory::class, NullConversationHistoryPuller::class);
     }
 
     public function boot(): void

--- a/app/Services/Memory/NullConversationHistoryPuller.php
+++ b/app/Services/Memory/NullConversationHistoryPuller.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Memory;
+
+use App\Contracts\Memory\PullsConversationHistory;
+use App\Data\Memory\ConversationMessageData;
+use DateTimeInterface;
+use Illuminate\Support\Collection;
+
+final readonly class NullConversationHistoryPuller implements PullsConversationHistory
+{
+    /**
+     * @return Collection<int, ConversationMessageData>
+     */
+    public function pendingMessagesFor(
+        int $userId,
+        ?DateTimeInterface $afterCreatedAt,
+        ?string $afterId,
+        int $limit,
+    ): Collection {
+        return new Collection;
+    }
+
+    public function countPendingFor(
+        int $userId,
+        ?DateTimeInterface $afterCreatedAt,
+        ?string $afterId,
+    ): int {
+        return 0;
+    }
+}

--- a/tests/Unit/Memory/NullMemoryDefaultsTest.php
+++ b/tests/Unit/Memory/NullMemoryDefaultsTest.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 use App\Contracts\Memory\DispatchesMemoryExtraction;
 use App\Contracts\Memory\ManagesMemoryContext;
+use App\Contracts\Memory\PullsConversationHistory;
+use App\Services\Memory\NullConversationHistoryPuller;
 use App\Services\Memory\NullMemoryExtractionDispatcher;
 use App\Services\Memory\NullMemoryPromptContext;
 
-covers(NullMemoryExtractionDispatcher::class, NullMemoryPromptContext::class);
+covers(
+    NullConversationHistoryPuller::class,
+    NullMemoryExtractionDispatcher::class,
+    NullMemoryPromptContext::class,
+);
 
 it('renders an empty memory context by default', function (): void {
     $context = new NullMemoryPromptContext;
@@ -27,7 +33,15 @@ it('ignores memory extraction dispatches by default', function (): void {
     expect($dispatcher)->toBeInstanceOf(DispatchesMemoryExtraction::class);
 });
 
+it('pulls no conversation history by default', function (): void {
+    $puller = new NullConversationHistoryPuller;
+
+    expect($puller->pendingMessagesFor(1, null, null, 10))->toBeEmpty()
+        ->and($puller->countPendingFor(1, null, null))->toBe(0);
+});
+
 it('resolves public memory contracts from the container', function (): void {
     expect(resolve(ManagesMemoryContext::class))->toBeInstanceOf(ManagesMemoryContext::class)
-        ->and(resolve(DispatchesMemoryExtraction::class))->toBeInstanceOf(DispatchesMemoryExtraction::class);
+        ->and(resolve(DispatchesMemoryExtraction::class))->toBeInstanceOf(DispatchesMemoryExtraction::class)
+        ->and(resolve(PullsConversationHistory::class))->toBeInstanceOf(PullsConversationHistory::class);
 });


### PR DESCRIPTION
## Summary

plate-core's \`MemoryExtractor\` needs to read conversation turns via a cross-boundary seam instead of directly importing \`App\Models\History\`. Per [.ai/guidelines/plate-core.blade.php](../blob/main/.ai/guidelines/plate-core.blade.php) — "The public app owns cross-boundary contracts" — the contract, DTO, and community-safe null implementation live here on \`main\` so the public app still boots without the private package. plate-core's Eloquent-backed implementation overrides the bindIf on the Cloud branch.

## Changes

- \`app/Contracts/Memory/PullsConversationHistory.php\` — new contract. Two methods: \`pendingMessagesFor()\` and \`countPendingFor()\`, both cursor-aware.
- \`app/Data/Memory/ConversationMessageData.php\` — new cross-boundary DTO (\`id\`, \`createdAt\`, \`role\`, \`content\`).
- \`app/Services/Memory/NullConversationHistoryPuller.php\` — empty fallback so extraction no-ops without plate-core.
- \`app/Providers/AppServiceProvider::register()\` — \`bindIf(PullsConversationHistory::class, NullConversationHistoryPuller::class)\` alongside the two existing memory bindIfs.
- \`tests/Unit/Memory/NullMemoryDefaultsTest\` — asserts the null returns empty + the container resolves the contract.
- \`.ai/guidelines/plate-core.blade.php\` — lists the new contract, DTO, and null in the enumerations; adds a "Cross-boundary DTOs live in" section.

## Verification

- \`vendor/bin/pest tests/Unit/Memory/NullMemoryDefaultsTest.php\` — 4/4 pass.
- \`vendor/bin/phpstan\` — green (0 errors on the full codebase at \`level: max\`).
- \`vendor/bin/pint --test\` on touched files — green after one \`phpdoc_type_annotations_only\` fix.

## Companion PR in plate-core

Pairs with [acara-app/plate-core#4](https://github.com/acara-app/plate-core/pull/4), which:
- Removes the (incorrectly added) interface stubs and the \`PullsConversationHistory\` contract from plate-core src.
- Adds \`src/Services/Memory/EloquentHistoryPuller.php\` as the real implementation (queries \`App\Models\History\`, maps to \`ConversationMessageData\`).
- Points \`config('memory.history_puller')\` default at \`EloquentHistoryPuller\`.

## Sequencing

Merge order that keeps both branches green:

1. Merge this PR to plate \`main\`.
2. Merge plate-core#4 to plate-core \`main\`.
3. Merge plate \`main\` into \`private/plate-core\` (standard flow).
4. On \`private/plate-core\`: \`composer update acara-app/plate-core --no-scripts\` to pick up the new lock.

Once step 4 lands, memory extraction queries real \`History\` rows through the new contract. On public \`main\`, extraction silently no-ops via the null puller — matching the existing behavior for \`ManagesMemoryContext\` / \`DispatchesMemoryExtraction\`.

This also supersedes [#247](../pull/247) (base \`private/plate-core\`), which put the real Eloquent implementation in plate and deleted plate's copies of the existing two contracts — the wrong direction per the guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)