### PR TITLE
fix(snap-to-track): remove capture attribute to allow mobile gallery uploads

### DIFF
--- a/resources/views/pages/⚡snap-to-track.blade.php
+++ b/resources/views/pages/⚡snap-to-track.blade.php
@@ -271,7 +271,6 @@ class extends Component
                             type="file"
                             wire:model="photo"
                             accept="image/*"
-                            capture="environment"
                             class="hidden"
                             id="photo-upload"
                             @disabled($loading || (App::environment(['production', 'testing']) && blank($turnstileToken)))


### PR DESCRIPTION
## Summary
- Removes `capture="environment"` from the file input on the snap-to-track page
- This attribute forced the camera on mobile devices and prevented selecting images from the photo gallery
- Without it, mobile browsers show the standard action sheet with both "Take Photo" and "Choose from Library" options

## Testing
- All 24 existing snap-to-track tests pass