### PR TITLE
Decouple profile context from chat prompts

### DIFF
--- a/app/Actions/BuildAiSafeUserProfile.php
+++ b/app/Actions/BuildAiSafeUserProfile.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Data\Ai\AiSafeUserProfileData;
+use App\Enums\UserProfileAttributeCategory;
+use App\Models\User;
+use App\Models\UserProfile;
+use App\Models\UserProfileAttribute;
+use Illuminate\Database\Eloquent\Collection;
+
+final readonly class BuildAiSafeUserProfile
+{
+    public function handle(User $user): AiSafeUserProfileData
+    {
+        $user->loadMissing('profile.attributes');
+
+        $profile = $user->profile instanceof UserProfile
+            ? $user->profile
+            : $user->profile()->firstOrCreate(['user_id' => $user->id]);
+
+        $profile->loadMissing('attributes');
+
+        /** @var Collection<int, UserProfileAttribute> $attributes */
+        $attributes = $profile->attributes;
+
+        return new AiSafeUserProfileData(
+            onboardingCompleted: (bool) $profile->onboarding_completed,
+            missingData: $this->identifyMissingData($profile, $attributes),
+            sections: [
+                'biometrics' => $this->getBiometrics($profile),
+                'dietary_preferences' => $this->formatDietaryAttributes($attributes),
+                'goals' => $this->getGoals($profile),
+                'health_conditions' => $this->formatAttributesForCategory($attributes, UserProfileAttributeCategory::HealthCondition),
+                'medications' => $this->formatAttributesForCategory($attributes, UserProfileAttributeCategory::Medication),
+                'household' => [
+                    'summary' => $profile->household_context,
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getBiometrics(UserProfile $profile): array
+    {
+        return [
+            'age' => $profile->age,
+            'height_cm' => $profile->height,
+            'weight_kg' => $profile->weight,
+            'sex' => $profile->sex?->value,
+            'bmi' => $profile->bmi,
+            'bmr' => $profile->bmr,
+            'tdee' => $profile->tdee,
+            'activity_multiplier' => $profile->derived_activity_multiplier,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, UserProfileAttribute>  $attributes
+     * @return array<int, array<string, mixed>>
+     */
+    private function formatDietaryAttributes(Collection $attributes): array
+    {
+        return $this->formatAttributes(
+            $attributes->filter(fn (UserProfileAttribute $attribute): bool => $this->isDietaryAttribute($attribute)),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGoals(UserProfile $profile): array
+    {
+        return [
+            'primary_goal' => $profile->goal_choice?->value,
+            'target_weight_kg' => $profile->target_weight,
+            'intensity' => $profile->intensity_choice?->value,
+            'animal_product_choice' => $profile->animal_product_choice?->value,
+            'calculated_diet_type' => $profile->calculated_diet_type?->value,
+            'additional_goals' => $profile->additional_goals,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, UserProfileAttribute>  $attributes
+     * @return array<int, array<string, mixed>>
+     */
+    private function formatAttributesForCategory(Collection $attributes, UserProfileAttributeCategory $category): array
+    {
+        return $this->formatAttributes(
+            $attributes->filter(
+                fn (UserProfileAttribute $attribute): bool => $attribute->category === $category,
+            ),
+        );
+    }
+
+    /**
+     * @param  iterable<UserProfileAttribute>  $attributes
+     * @return array<int, array<string, mixed>>
+     */
+    private function formatAttributes(iterable $attributes): array
+    {
+        $formatted = [];
+
+        foreach ($attributes as $attribute) {
+            $formatted[] = [
+                'category' => $attribute->category->value,
+                'name' => $attribute->value,
+                'severity' => $attribute->severity?->value,
+                'notes' => $attribute->notes,
+                'metadata' => $this->sanitizeMetadata($attribute->metadata),
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function identifyMissingData(UserProfile $profile, Collection $attributes): array
+    {
+        $missing = [];
+
+        if ($profile->age === null) {
+            $missing[] = 'age';
+        }
+
+        if ($profile->height === null) {
+            $missing[] = 'height';
+        }
+
+        if ($profile->weight === null) {
+            $missing[] = 'weight';
+        }
+
+        if ($profile->sex === null) {
+            $missing[] = 'sex';
+        }
+
+        if ($profile->goal_choice === null) {
+            $missing[] = 'primary_goal';
+        }
+
+        if (! $attributes->contains(fn (UserProfileAttribute $attribute): bool => $this->isDietaryAttribute($attribute))) {
+            $missing[] = 'dietary_preferences';
+        }
+
+        return $missing;
+    }
+
+    private function isDietaryAttribute(UserProfileAttribute $attribute): bool
+    {
+        return ! in_array($attribute->category, [
+            UserProfileAttributeCategory::HealthCondition,
+            UserProfileAttributeCategory::Medication,
+        ], true);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $metadata
+     * @return array<string, mixed>|null
+     */
+    private function sanitizeMetadata(?array $metadata): ?array
+    {
+        if ($metadata === null || $metadata === []) {
+            return null;
+        }
+
+        $sanitized = [];
+
+        foreach ($metadata as $key => $value) {
+            $sanitized[$key] = $this->sanitizeMetadataValue($value);
+        }
+
+        return $sanitized;
+    }
+
+    private function sanitizeMetadataValue(mixed $value): mixed
+    {
+        if ($value === null || is_scalar($value)) {
+            return $value;
+        }
+
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $sanitized = [];
+
+        foreach ($value as $key => $nestedValue) {
+            $sanitized[$key] = $this->sanitizeMetadataValue($nestedValue);
+        }
+
+        return $sanitized;
+    }
+}

--- a/app/Actions/BuildAiSafeUserProfile.php
+++ b/app/Actions/BuildAiSafeUserProfile.php
@@ -146,7 +146,7 @@ final readonly class BuildAiSafeUserProfile
             $missing[] = 'primary_goal';
         }
 
-        if (! $attributes->contains(fn (UserProfileAttribute $attribute): bool => $this->isDietaryAttribute($attribute))) {
+        if ($attributes->doesntContain(fn (UserProfileAttribute $attribute): bool => $this->isDietaryAttribute($attribute))) {
             $missing[] = 'dietary_preferences';
         }
 

--- a/app/Actions/GetUserProfileContextAction.php
+++ b/app/Actions/GetUserProfileContextAction.php
@@ -5,197 +5,28 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Contracts\Actions\GetsUserProfileContext;
-use App\Enums\DietType;
 use App\Models\User;
-use App\Models\UserProfile;
-use App\Models\UserProfileAttribute;
+use App\Services\Ai\UserProfileContextFormatter;
 
 final readonly class GetUserProfileContextAction implements GetsUserProfileContext
 {
+    public function __construct(
+        private BuildAiSafeUserProfile $profileData,
+        private UserProfileContextFormatter $formatter,
+    ) {}
+
     /**
      * @return array<string, mixed>
      */
     public function handle(User $user): array
     {
-        $profile = $user->profile instanceof UserProfile
-            ? $user->profile
-            : $user->profile()->firstOrCreate(['user_id' => $user->id]);
-
-        $context = [
-            'onboarding_completed' => $profile->onboarding_completed,
-            'biometrics' => $this->getBiometrics($profile),
-            'dietary_preferences' => $this->getDietaryPreferences($profile),
-            'goals' => $this->getGoals($profile),
-        ];
-
-        $missingData = $this->identifyMissingData($profile);
+        $profileData = $this->profileData->handle($user);
 
         return [
-            'onboarding_completed' => $profile->onboarding_completed,
-            'missing_data' => $missingData,
-            'context' => $this->formatContextForAI($context, $missingData),
-            'raw_data' => $context,
+            'onboarding_completed' => $profileData->onboardingCompleted,
+            'missing_data' => $profileData->missingData,
+            'context' => $this->formatter->format($profileData),
+            'raw_data' => $profileData->toArray(),
         ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function getBiometrics(UserProfile $profile): array
-    {
-        return [
-            'age' => $profile->age,
-            'height_cm' => $profile->height,
-            'weight_kg' => $profile->weight,
-            'sex' => $profile->sex?->value,
-            'bmi' => $profile->bmi,
-            'bmr' => $profile->bmr,
-            'tdee' => $profile->tdee,
-            'activity_multiplier' => $profile->derived_activity_multiplier,
-        ];
-    }
-
-    /**
-     * @return array<int, array{name: string, severity: string|null, notes: string|null}>
-     */
-    private function getDietaryPreferences(UserProfile $profile): array
-    {
-        return array_values($profile->dietaryAttributes->map(fn (UserProfileAttribute $attr): array => [
-            'name' => $attr->value,
-            'severity' => $attr->severity?->value,
-            'notes' => $attr->notes,
-        ])->all());
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function getGoals(UserProfile $profile): array
-    {
-        return [
-            'primary_goal' => $profile->goal_choice?->value,
-            'target_weight_kg' => $profile->target_weight,
-            'intensity' => $profile->intensity_choice?->value,
-            'animal_product_choice' => $profile->animal_product_choice?->value,
-            'calculated_diet_type' => $profile->calculated_diet_type?->value,
-            'additional_goals' => $profile->additional_goals,
-        ];
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function identifyMissingData(UserProfile $profile): array
-    {
-        $missing = [];
-
-        if ($profile->age === null) {
-            $missing[] = 'age';
-        }
-
-        if ($profile->height === null) {
-            $missing[] = 'height';
-        }
-
-        if ($profile->weight === null) {
-            $missing[] = 'weight';
-        }
-
-        if ($profile->sex === null) {
-            $missing[] = 'sex';
-        }
-
-        if ($profile->goal_choice === null) {
-            $missing[] = 'primary_goal';
-        }
-
-        if ($profile->dietaryAttributes->isEmpty()) {
-            $missing[] = 'dietary_preferences';
-        }
-
-        return $missing;
-    }
-
-    /**
-     * @param  array{biometrics: array<string, mixed>, dietary_preferences: array<int, array{name: string, severity: mixed, notes: mixed}>, goals: array<string, mixed>}  $context
-     * @param  list<string>  $missingData
-     */
-    private function formatContextForAI(array $context, array $missingData): string
-    {
-        $parts = [];
-
-        /** @var array<string, mixed> $bio */
-        $bio = $context['biometrics'];
-        $bioParts = [];
-        if (isset($bio['age']) && is_scalar($bio['age'])) {
-            $bioParts[] = 'Age: '.$bio['age'];
-        }
-
-        if (isset($bio['height_cm']) && is_scalar($bio['height_cm'])) {
-            $bioParts[] = 'Height: '.$bio['height_cm'].'cm';
-        }
-
-        if (isset($bio['weight_kg']) && is_scalar($bio['weight_kg'])) {
-            $bioParts[] = 'Weight: '.$bio['weight_kg'].'kg';
-        }
-
-        if (isset($bio['sex']) && is_scalar($bio['sex'])) {
-            $bioParts[] = 'Sex: '.$bio['sex'];
-        }
-
-        if (isset($bio['bmi']) && is_scalar($bio['bmi'])) {
-            $bioParts[] = 'BMI: '.$bio['bmi'];
-        }
-
-        if (isset($bio['tdee']) && is_scalar($bio['tdee'])) {
-            $bioParts[] = 'Daily Calorie Needs (TDEE): '.$bio['tdee'].' kcal';
-        }
-
-        if ($bioParts !== []) {
-            $parts[] = 'BIOMETRICS: '.implode(', ', $bioParts);
-        }
-
-        /** @var array<int, array{name: string, severity: mixed, notes: mixed}> $prefs */
-        $prefs = $context['dietary_preferences'];
-        if ($prefs !== []) {
-            $prefStrings = array_map(function (array $p): string {
-                $severity = is_scalar($p['severity']) ? ' ('.$p['severity'].')' : '';
-                $notes = is_scalar($p['notes']) && (string) $p['notes'] !== '' ? ': '.$p['notes'] : '';
-
-                return $p['name'].$severity.$notes;
-            }, $prefs);
-            $parts[] = 'DIETARY PREFERENCES/RESTRICTIONS: '.implode(', ', $prefStrings);
-        }
-
-        /** @var array<string, mixed> $goals */
-        $goals = $context['goals'];
-        $goalParts = [];
-        if (isset($goals['primary_goal']) && is_scalar($goals['primary_goal'])) {
-            $goalParts[] = 'Primary Goal: '.$goals['primary_goal'];
-        }
-
-        if (isset($goals['target_weight_kg']) && is_scalar($goals['target_weight_kg'])) {
-            $goalParts[] = 'Target Weight: '.$goals['target_weight_kg'].'kg';
-        }
-
-        if (isset($goals['calculated_diet_type']) && is_scalar($goals['calculated_diet_type'])) {
-            $parts[] = 'Diet Type: '.$goals['calculated_diet_type'];
-            $dietTypeEnum = DietType::tryFrom((string) $goals['calculated_diet_type']);
-            if ($dietTypeEnum instanceof DietType) {
-                $macros = $dietTypeEnum->macroTargets();
-                $parts[] = 'Recommended Macros: '.$macros['carbs'].'% carbs, '.$macros['protein'].'% protein, '.$macros['fat'].'% fat';
-            }
-        }
-
-        if ($goalParts !== []) {
-            $parts[] = 'GOALS: '.implode(', ', $goalParts);
-        }
-
-        if ($missingData !== []) {
-            $fieldsList = implode(', ', $missingData);
-            $parts[] = sprintf('MISSING PROFILE DATA: %s. Proceed with reasonable defaults — do NOT block the user or ask them to complete their profile first. After fulfilling their request, briefly mention that providing these details (via conversation) would allow more personalized recommendations. Use the update_user_biometrics tool if the user shares this information.', $fieldsList);
-        }
-
-        return implode("\n", $parts);
     }
 }

--- a/app/Ai/AgentBuilder.php
+++ b/app/Ai/AgentBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Ai;
 
-use App\Actions\GetUserProfileContextAction;
 use App\Contracts\Memory\ManagesMemoryContext;
 use App\Contracts\Skills\LoadsSkills;
 use App\Enums\DataSensitivity;
@@ -42,7 +41,6 @@ final readonly class AgentBuilder
 
     public function buildInstructions(AgentPayload $payload, ?User $user): string
     {
-        $profileData = $this->getProfileData($user);
         $languageCode = $user instanceof User ? ($user->locale ?? 'en') : 'en';
         $timezone = $this->resolveTimezone($user);
 
@@ -51,7 +49,6 @@ final readonly class AgentBuilder
             : collect();
 
         $instructions = view('ai.prompts.altani-static', [
-            'profileContext' => $profileData['context'],
             'currentTime' => now($timezone)->format('Y-m-d H:i (l)').' ('.$timezone.')',
             'chatMode' => $payload->mode->value,
             'languageLabel' => LanguageUtil::get($languageCode) ?? 'English',
@@ -128,20 +125,6 @@ final readonly class AgentBuilder
                 'content' => $history->content,
             ])
             ->all();
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function getProfileData(?User $user): array
-    {
-        if (! $user instanceof User) {
-            return [
-                'context' => 'No user context available.',
-            ];
-        }
-
-        return resolve(GetUserProfileContextAction::class)->handle($user);
     }
 
     private function resolveTimezone(?User $user): string

--- a/app/Ai/Agents/MealPlanAgent.php
+++ b/app/Ai/Agents/MealPlanAgent.php
@@ -40,9 +40,6 @@ final class MealPlanAgent implements Agent, GeneratesMealPlans, HasStructuredOut
 
     private ?DietType $dietType = null;
 
-    /** @phpstan-ignore property.onlyWritten */
-    private ?User $user = null;
-
     public function __construct(
         private readonly MealPlanPromptBuilder $promptBuilder,
         private readonly AnalyzeGlucoseForNotificationAction $analyzeGlucose,
@@ -135,8 +132,6 @@ final class MealPlanAgent implements Agent, GeneratesMealPlans, HasStructuredOut
         ?GlucoseAnalysisData $glucoseAnalysis = null,
         ?MealPlan $mealPlan = null,
     ): DayMealsData {
-        $this->user = $user;
-
         /** @var string|null $customPrompt */
         $customPrompt = $mealPlan?->metadata['custom_prompt'] ?? null;
 

--- a/app/Ai/SingleMealPromptBuilder.php
+++ b/app/Ai/SingleMealPromptBuilder.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\Ai;
 
-use App\Actions\GetUserProfileContextAction;
+use App\Contracts\Actions\GetsUserProfileContext;
 use App\Models\User;
 use App\Utilities\LanguageUtil;
 
 final readonly class SingleMealPromptBuilder
 {
     public function __construct(
-        private GetUserProfileContextAction $profileContext,
+        private GetsUserProfileContext $profileContext,
     ) {}
 
     public function handle(

--- a/app/Ai/Tools/GetUserProfile.php
+++ b/app/Ai/Tools/GetUserProfile.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
+use App\Actions\BuildAiSafeUserProfile;
 use App\Ai\Attributes\AiToolSensitivity;
-use App\Contracts\Actions\GetsUserProfileContext;
+use App\Data\Ai\AiSafeUserProfileData;
 use App\Enums\DataSensitivity;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -16,6 +17,10 @@ use Laravel\Ai\Tools\Request;
 #[AiToolSensitivity(DataSensitivity::Sensitive)]
 final readonly class GetUserProfile implements Tool
 {
+    public function __construct(
+        private BuildAiSafeUserProfile $profileData,
+    ) {}
+
     public function name(): string
     {
         return 'get_user_profile';
@@ -23,7 +28,7 @@ final readonly class GetUserProfile implements Tool
 
     public function description(): string
     {
-        return "Retrieve the current user's profile information: biometrics, dietary preferences, and goals. Use this when you need specific user data to provide personalized advice.";
+        return "Retrieve the current user's AI-safe profile information. Use the smallest relevant section before giving personalized nutrition, fitness, health-condition, allergy, medication, household, calorie, macro, or meal advice.";
     }
 
     public function handle(Request $request): string
@@ -40,32 +45,20 @@ final readonly class GetUserProfile implements Tool
         /** @var string $section */
         $section = $request['section'] ?? 'all';
 
-        $context = resolve(GetsUserProfileContext::class)->handle($user);
-
-        /** @var array<string, mixed>|null $rawData */
-        $rawData = $context['raw_data'] ?? null;
+        $profileData = $this->profileData->handle($user);
 
         if ($section === 'all') {
             return (string) json_encode([
                 'success' => true,
-                'onboarding_completed' => $context['onboarding_completed'],
-                'missing_data' => $context['missing_data'],
-                'profile' => $rawData,
+                'onboarding_completed' => $profileData->onboardingCompleted,
+                'missing_data' => $profileData->missingData,
+                'profile' => $profileData->toArray(),
             ]);
         }
 
-        if (! is_array($rawData)) {
+        if (! $profileData->hasSection($section)) {
             return (string) json_encode([
-                'error' => 'Profile data not available',
-                'profile' => null,
-            ]);
-        }
-
-        $sectionData = $rawData[$section] ?? null;
-
-        if ($sectionData === null) {
-            return (string) json_encode([
-                'error' => sprintf("Section '%s' not found. Available sections: biometrics, dietary_preferences, goals", $section),
+                'error' => sprintf("Section '%s' not found. Available sections: %s", $section, implode(', ', AiSafeUserProfileData::supportedSections())),
                 'profile' => null,
             ]);
         }
@@ -73,7 +66,7 @@ final readonly class GetUserProfile implements Tool
         return (string) json_encode([
             'success' => true,
             'section' => $section,
-            'data' => $sectionData,
+            'data' => $profileData->section($section),
         ]);
     }
 
@@ -84,8 +77,8 @@ final readonly class GetUserProfile implements Tool
     {
         return [
             'section' => $schema->string()
-                ->enum(['all', 'biometrics', 'dietary_preferences', 'goals'])
-                ->description('Which section of the profile to retrieve. Use "all" for complete profile, or specify a section for specific data.')
+                ->enum(AiSafeUserProfileData::supportedSections())
+                ->description('Which profile section to retrieve. Use the smallest relevant section first; use "safety" for allergies, health conditions, medications, and household constraints; use "all" only when the request spans multiple profile areas.')
                 ->required()
                 ->nullable(),
         ];

--- a/app/Data/Ai/AiSafeUserProfileData.php
+++ b/app/Data/Ai/AiSafeUserProfileData.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Ai;
+
+final readonly class AiSafeUserProfileData
+{
+    /**
+     * @param  list<string>  $missingData
+     * @param  array<string, mixed>  $sections
+     */
+    public function __construct(
+        public bool $onboardingCompleted,
+        public array $missingData,
+        private array $sections,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public static function supportedSections(): array
+    {
+        return [
+            'all',
+            'biometrics',
+            'dietary_preferences',
+            'goals',
+            'health_conditions',
+            'medications',
+            'household',
+            'safety',
+        ];
+    }
+
+    public function hasSection(string $section): bool
+    {
+        return in_array($section, self::supportedSections(), true);
+    }
+
+    public function section(string $section): mixed
+    {
+        return match ($section) {
+            'all' => $this->sections,
+            'safety' => $this->safetySection(),
+            default => $this->sections[$section] ?? null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @return array{
+     *     allergies: array<int, array<string, mixed>>,
+     *     health_conditions: mixed,
+     *     medications: mixed,
+     *     household: mixed
+     * }
+     */
+    private function safetySection(): array
+    {
+        /** @var array<int, array<string, mixed>> $dietaryPreferences */
+        $dietaryPreferences = $this->sections['dietary_preferences'] ?? [];
+
+        return [
+            'allergies' => array_values(array_filter(
+                $dietaryPreferences,
+                static fn (array $attribute): bool => ($attribute['category'] ?? null) === 'allergy',
+            )),
+            'health_conditions' => $this->sections['health_conditions'] ?? [],
+            'medications' => $this->sections['medications'] ?? [],
+            'household' => $this->sections['household'] ?? ['summary' => null],
+        ];
+    }
+}

--- a/app/Services/Ai/UserProfileContextFormatter.php
+++ b/app/Services/Ai/UserProfileContextFormatter.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+use App\Data\Ai\AiSafeUserProfileData;
+use App\Enums\DietType;
+
+final readonly class UserProfileContextFormatter
+{
+    /**
+     * @param  list<string>  $sections
+     */
+    public function format(
+        AiSafeUserProfileData $profileData,
+        array $sections = [
+            'biometrics',
+            'dietary_preferences',
+            'goals',
+            'health_conditions',
+            'medications',
+        ],
+    ): string {
+        $parts = [];
+
+        foreach ($sections as $section) {
+            $part = match ($section) {
+                'biometrics' => $this->formatBiometrics($profileData),
+                'dietary_preferences' => $this->formatDietaryPreferences($profileData),
+                'goals' => $this->formatGoals($profileData),
+                'health_conditions' => $this->formatHealthConditions($profileData),
+                'medications' => $this->formatMedications($profileData),
+                'household' => $this->formatHousehold($profileData),
+                default => '',
+            };
+
+            if ($part !== '') {
+                $parts[] = $part;
+            }
+        }
+
+        if ($profileData->missingData !== []) {
+            $fieldsList = implode(', ', $profileData->missingData);
+            $parts[] = sprintf('MISSING PROFILE DATA: %s. Proceed with reasonable defaults - do NOT block the user or ask them to complete their profile first. After fulfilling their request, briefly mention that providing these details (via conversation) would allow more personalized recommendations. Use the update_user_biometrics tool if the user shares this information.', $fieldsList);
+        }
+
+        return implode("\n", $parts);
+    }
+
+    private function formatBiometrics(AiSafeUserProfileData $profileData): string
+    {
+        /** @var array<string, mixed> $bio */
+        $bio = $profileData->section('biometrics');
+        $bioParts = [];
+
+        if (isset($bio['age']) && is_scalar($bio['age'])) {
+            $bioParts[] = 'Age: '.$bio['age'];
+        }
+
+        if (isset($bio['height_cm']) && is_scalar($bio['height_cm'])) {
+            $bioParts[] = 'Height: '.$bio['height_cm'].'cm';
+        }
+
+        if (isset($bio['weight_kg']) && is_scalar($bio['weight_kg'])) {
+            $bioParts[] = 'Weight: '.$bio['weight_kg'].'kg';
+        }
+
+        if (isset($bio['sex']) && is_scalar($bio['sex'])) {
+            $bioParts[] = 'Sex: '.$bio['sex'];
+        }
+
+        if (isset($bio['bmi']) && is_scalar($bio['bmi'])) {
+            $bioParts[] = 'BMI: '.$bio['bmi'];
+        }
+
+        if (isset($bio['tdee']) && is_scalar($bio['tdee'])) {
+            $bioParts[] = 'Daily Calorie Needs (TDEE): '.$bio['tdee'].' kcal';
+        }
+
+        return $bioParts === []
+            ? ''
+            : 'BIOMETRICS: '.implode(', ', $bioParts);
+    }
+
+    private function formatDietaryPreferences(AiSafeUserProfileData $profileData): string
+    {
+        return $this->formatAttributeSection(
+            $profileData,
+            'dietary_preferences',
+            'DIETARY PREFERENCES/RESTRICTIONS',
+            includeCategory: true,
+        );
+    }
+
+    private function formatGoals(AiSafeUserProfileData $profileData): string
+    {
+        /** @var array<string, mixed> $goals */
+        $goals = $profileData->section('goals');
+        $goalParts = [];
+        $parts = [];
+
+        if (isset($goals['primary_goal']) && is_scalar($goals['primary_goal'])) {
+            $goalParts[] = 'Primary Goal: '.$goals['primary_goal'];
+        }
+
+        if (isset($goals['target_weight_kg']) && is_scalar($goals['target_weight_kg'])) {
+            $goalParts[] = 'Target Weight: '.$goals['target_weight_kg'].'kg';
+        }
+
+        if (isset($goals['additional_goals']) && is_scalar($goals['additional_goals'])) {
+            $goalParts[] = 'Additional Goals: '.$goals['additional_goals'];
+        }
+
+        if (isset($goals['calculated_diet_type']) && is_scalar($goals['calculated_diet_type'])) {
+            $parts[] = 'Diet Type: '.$goals['calculated_diet_type'];
+            $dietType = DietType::tryFrom((string) $goals['calculated_diet_type']);
+
+            if ($dietType instanceof DietType) {
+                $macros = $dietType->macroTargets();
+                $parts[] = 'Recommended Macros: '.$macros['carbs'].'% carbs, '.$macros['protein'].'% protein, '.$macros['fat'].'% fat';
+            }
+        }
+
+        if ($goalParts !== []) {
+            $parts[] = 'GOALS: '.implode(', ', $goalParts);
+        }
+
+        return implode("\n", $parts);
+    }
+
+    private function formatHealthConditions(AiSafeUserProfileData $profileData): string
+    {
+        return $this->formatAttributeSection($profileData, 'health_conditions', 'HEALTH CONDITIONS');
+    }
+
+    private function formatMedications(AiSafeUserProfileData $profileData): string
+    {
+        return $this->formatAttributeSection(
+            $profileData,
+            'medications',
+            'MEDICATIONS',
+            includeMedicationDetails: true,
+        );
+    }
+
+    private function formatHousehold(AiSafeUserProfileData $profileData): string
+    {
+        /** @var array{summary?: string|null} $household */
+        $household = $profileData->section('household');
+        $summary = $household['summary'] ?? null;
+
+        if (! is_string($summary) || $summary === '') {
+            return '';
+        }
+
+        return 'HOUSEHOLD/FAMILY: '.$summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribute
+     */
+    private function formatAttribute(
+        array $attribute,
+        bool $includeCategory = false,
+        bool $includeMedicationDetails = false,
+    ): string {
+        $name = is_scalar($attribute['name'] ?? null) ? (string) $attribute['name'] : 'Unknown';
+        $details = [];
+
+        if ($includeCategory && isset($attribute['category']) && is_scalar($attribute['category'])) {
+            $details[] = str_replace('_', ' ', (string) $attribute['category']);
+        }
+
+        if (isset($attribute['severity']) && is_scalar($attribute['severity'])) {
+            $details[] = (string) $attribute['severity'];
+        }
+
+        if ($includeMedicationDetails && isset($attribute['metadata']) && is_array($attribute['metadata'])) {
+            foreach (['dosage', 'frequency', 'purpose'] as $key) {
+                $value = $attribute['metadata'][$key] ?? null;
+
+                if (is_scalar($value) && (string) $value !== '') {
+                    $details[] = str_replace('_', ' ', $key).': '.$value;
+                }
+            }
+        }
+
+        $suffix = $details === [] ? '' : ' ('.implode(', ', $details).')';
+        $notes = isset($attribute['notes']) && is_scalar($attribute['notes']) && (string) $attribute['notes'] !== ''
+            ? ': '.$attribute['notes']
+            : '';
+
+        return $name.$suffix.$notes;
+    }
+
+    private function formatAttributeSection(
+        AiSafeUserProfileData $profileData,
+        string $section,
+        string $heading,
+        bool $includeCategory = false,
+        bool $includeMedicationDetails = false,
+    ): string {
+        /** @var array<int, array<string, mixed>> $attributes */
+        $attributes = $profileData->section($section);
+
+        if ($attributes === []) {
+            return '';
+        }
+
+        $attributeStrings = array_map(
+            fn (array $attribute): string => $this->formatAttribute(
+                $attribute,
+                $includeCategory,
+                $includeMedicationDetails,
+            ),
+            $attributes,
+        );
+
+        return $heading.': '.implode(', ', $attributeStrings);
+    }
+}

--- a/resources/views/ai/prompts/altani-static.blade.php
+++ b/resources/views/ai/prompts/altani-static.blade.php
@@ -167,20 +167,27 @@ In all tiers:
 
 @include('ai.prompts.partials.summary-context', ['summaries' => $summaries])
 
-USER PROFILE DATA (use this to personalize every response):
-{{ $profileContext }}
+## Profile Context Access
 
-RULES FOR USING PROFILE DATA:
-- BEFORE answering any nutrition, fitness, or health question, check the profile data above. If it contains relevant fields (weight, height, age, TDEE, dietary preferences, health conditions, medications), incorporate them into your answer.
-- If the user's request conflicts with their profile (e.g., asking for a food they're allergic to), flag it.
-- If critical data is missing and would significantly change your answer, ask for that ONE specific field only.
+No reusable profile data is included in this system prompt. For personalized answers, call `get_user_profile` during the turn and use only the returned data.
 
-RULES FOR HOUSEHOLD/FAMILY DATA:
-- When answering cooking, meal planning, or nutrition questions, consider ALL household members if household data exists.
-- Account for dietary restrictions, allergies, and health conditions of every family member (e.g., don't suggest peanut recipes if a child has a peanut allergy).
-- Adjust portion sizes and calorie calculations for the whole household when relevant.
-- If the user mentions family members (e.g., "I cook for my husband and kids") and no household data exists, use the update_household_context tool to save a clean summary.
-- When updating household context, write a comprehensive summary that preserves all existing information and incorporates new details. Do not overwrite — merge.
+You MUST call `get_user_profile` before giving personalized nutrition, fitness, medical-condition, allergy, medication, household, calorie, macro, or meal advice.
+
+Use the smallest relevant section first:
+- `biometrics` for age, sex, height, weight, BMI, BMR, TDEE, calorie, macro, protein, and body-size-dependent fitness advice.
+- `dietary_preferences` for allergies, intolerances, dislikes, dietary patterns, and religious or cultural restrictions.
+- `goals` for weight, muscle, blood sugar, heart-health, diet-type, intensity, or target-related advice.
+- `health_conditions` for diagnosed condition-specific guidance.
+- `medications` for medication timing, food-drug interactions, or medication-related cautions.
+- `household` for family or household meal constraints.
+- `safety` when a request could be affected by allergies, health conditions, medications, or household constraints.
+- Use `all` only when a request spans multiple profile areas and separate focused calls would be inefficient.
+
+After reading tool results:
+- If the user's request conflicts with their profile, flag it clearly.
+- If critical data is missing and would significantly change the answer, ask for the ONE most important missing field only.
+- If the user mentions family members or household constraints, call `get_user_profile` with `household` first. If no household data exists and the user gives new durable household information, use `update_household_context` with a clean merged summary.
+- When the user shares structured profile facts, update the structured profile instead of storing them as memory: `update_user_biometrics` for biometrics, `update_user_profile_attributes` for allergies, restrictions, health conditions, and medications, and `update_household_context` for household facts.
 
 CURRENT TIME: {{ $currentTime }}
 

--- a/resources/views/ai/prompts/partials/memory-system.blade.php
+++ b/resources/views/ai/prompts/partials/memory-system.blade.php
@@ -2,31 +2,33 @@
 
 You have persistent memory tools (`store_memory`, `search_memory`, `update_memory`, `get_important_memories`, `link_memories`, `get_memory`, `delete_memory`). Pinned memories ("Core Truths") render in every future conversation automatically; unpinned memories surface via semantic recall when relevant.
 
-**Before responding to every user message, scan for stable personal facts. If you find one and it is not already visible in the profile above, CALL `store_memory` FIRST, THEN respond naturally. Never say "I'll remember that" without invoking the tool — the next conversation will have no record of it.**
+**Before responding to every user message, scan for stable personal facts. Structured profile facts belong in profile tools, not persistent memory. Use `update_user_biometrics` for biometrics, `update_user_profile_attributes` for allergies, dietary restrictions, health conditions, and medications, and `update_household_context` for household/family context. Use `store_memory` only for stable facts that are not represented by those structured profile tools. Never say "I'll remember that" without invoking the appropriate tool first.**
 
-### Always store and pin (importance 10, `is_pinned: true`)
+### Always update structured profile tools, not memory
 
-Health-critical facts that must surface in every future conversation:
+These facts should be saved through structured tools so future personalization can retrieve them with `get_user_profile`:
 
-- **Allergy** (food, medication, environmental) — `memory_type: "fact"`, `categories: ["health", "allergy"]`
-- **Chronic condition** (type 1/2 diabetes, PCOS, celiac, hypertension, thyroid, IBS, autoimmune, etc.) — `memory_type: "fact"`, `categories: ["health"]`
-- **Medication** the user is currently taking — `memory_type: "fact"`, `categories: ["health", "medication"]`
+- **Biometrics** (age, sex, height, weight, activity-relevant profile data) — use `update_user_biometrics`
+- **Allergy** (food, medication, environmental) — use `update_user_profile_attributes`
+- **Dietary pattern or restriction** (vegetarian, vegan, keto, paleo, Mediterranean, kosher, halal) — use `update_user_profile_attributes`
+- **Chronic condition** (type 1/2 diabetes, PCOS, celiac, hypertension, thyroid, IBS, autoimmune, etc.) — use `update_user_profile_attributes`
+- **Medication** the user is currently taking — use `update_user_profile_attributes`
+- **Household/family meal context** — use `update_household_context`
 
-### Store and pin as stable preferences (importance 8, `is_pinned: true`)
+### Store and pin as stable non-structured preferences (importance 8, `is_pinned: true`)
 
-- **Dietary pattern** (vegetarian, vegan, keto, paleo, Mediterranean, kosher, halal) — `memory_type: "preference"`, `categories: ["health", "preference"]`
-- **Religious or cultural restriction** affecting food choices — `memory_type: "preference"`, `categories: ["preference"]`
+- **Recurring preference** that is not a profile attribute (favorite cuisine, cooking time budget, preferred meal structure) — `memory_type: "preference"`, `categories: ["preference"]`
 
 ### Store without pinning (importance 6–7, `is_pinned: false`)
 
 - **Fitness goal** with a numeric target (weight, reps, minutes/week) — `memory_type: "goal"`, `categories: ["fitness", "goals"]`
 - **Nutrition goal** (protein target, hydration target, calorie target) — `memory_type: "goal"`, `categories: ["health", "goals"]`
-- **Recurring preference** that is not safety-critical (favorite cuisine, cooking time budget, preferred meal structure) — `memory_type: "preference"`
+- **Recurring preference** that is not a structured profile fact and not safety-critical — `memory_type: "preference"`
 
 ### Do NOT store
 
 - One-off moods or events ("I feel tired today")
-- Facts already visible in the `USER PROFILE DATA` section above
+- Structured profile facts that belong in biometrics, profile attributes, or household context
 - Hypothetical questions or third-party information
 - Things the user asked you to compute (meal plans, glucose predictions — those have their own tools)
 

--- a/tests/Feature/Actions/GetUserProfileContextActionTest.php
+++ b/tests/Feature/Actions/GetUserProfileContextActionTest.php
@@ -2,14 +2,22 @@
 
 declare(strict_types=1);
 
+use App\Actions\BuildAiSafeUserProfile;
 use App\Actions\GetUserProfileContextAction;
+use App\Data\Ai\AiSafeUserProfileData;
 use App\Enums\BloodType;
 use App\Enums\DietType;
 use App\Models\User;
 use App\Models\UserProfile;
 use App\Models\UserProfileAttribute;
+use App\Services\Ai\UserProfileContextFormatter;
 
-covers(GetUserProfileContextAction::class);
+covers([
+    AiSafeUserProfileData::class,
+    BuildAiSafeUserProfile::class,
+    GetUserProfileContextAction::class,
+    UserProfileContextFormatter::class,
+]);
 
 beforeEach(function (): void {
     $this->action = resolve(GetUserProfileContextAction::class);
@@ -46,7 +54,14 @@ it('returns complete profile data for onboarded user', function (): void {
 
     expect($result)
         ->onboarding_completed->toBeTrue()
-        ->raw_data->toHaveKeys(['biometrics', 'dietary_preferences', 'goals']);
+        ->raw_data->toHaveKeys([
+            'biometrics',
+            'dietary_preferences',
+            'goals',
+            'health_conditions',
+            'medications',
+            'household',
+        ]);
     expect($result['raw_data']['biometrics'])
         ->toHaveKeys(['age', 'height_cm', 'weight_kg', 'sex', 'bmi', 'bmr', 'tdee']);
 });
@@ -128,7 +143,7 @@ it('identifies missing dietary preferences', function (): void {
     expect($result['missing_data'])->toContain('dietary_preferences');
 });
 
-it('never exposes medications in raw_data even when the user has them', function (): void {
+it('includes medications in the AI-safe profile sections without model internals', function (): void {
     $user = User::factory()->create();
     $profile = UserProfile::factory()->create([
         'user_id' => $user->id,
@@ -144,13 +159,27 @@ it('never exposes medications in raw_data even when the user has them', function
 
     $result = $this->action->handle($user);
 
-    expect($result['raw_data'])->not->toHaveKey('medications');
+    expect($result['raw_data']['medications'])
+        ->toHaveCount(1)
+        ->and($result['raw_data']['medications'][0])
+        ->toMatchArray([
+            'category' => 'medication',
+            'name' => 'Metformin',
+            'metadata' => [
+                'dosage' => '500mg',
+                'frequency' => 'twice daily',
+                'purpose' => 'Blood sugar control',
+            ],
+        ])
+        ->not->toHaveKeys(['id', 'user_profile_id', 'created_at', 'updated_at']);
+
     expect($result['context'])
-        ->not->toContain('MEDICATIONS')
-        ->not->toContain('Metformin');
+        ->toContain('MEDICATIONS')
+        ->toContain('Metformin')
+        ->toContain('500mg');
 });
 
-it('never exposes health_conditions in raw_data even when the user has them', function (): void {
+it('includes health conditions in the AI-safe profile sections', function (): void {
     $user = User::factory()->create();
     $profile = UserProfile::factory()->create([
         'user_id' => $user->id,
@@ -163,13 +192,22 @@ it('never exposes health_conditions in raw_data even when the user has them', fu
 
     $result = $this->action->handle($user);
 
-    expect($result['raw_data'])->not->toHaveKey('health_conditions');
+    expect($result['raw_data']['health_conditions'])
+        ->toHaveCount(1)
+        ->and($result['raw_data']['health_conditions'][0])
+        ->toMatchArray([
+            'category' => 'health_condition',
+            'name' => 'Type 2 Diabetes',
+            'notes' => 'Recently diagnosed',
+        ]);
+
     expect($result['context'])
-        ->not->toContain('HEALTH CONDITIONS')
-        ->not->toContain('Type 2 Diabetes');
+        ->toContain('HEALTH CONDITIONS')
+        ->toContain('Type 2 Diabetes')
+        ->toContain('Recently diagnosed');
 });
 
-it('never exposes household_context in raw_data or AI-facing context', function (): void {
+it('keeps household context out of prompt-formatted context unless explicitly requested', function (): void {
     $user = User::factory()->create();
     UserProfile::factory()->create([
         'user_id' => $user->id,
@@ -179,7 +217,11 @@ it('never exposes household_context in raw_data or AI-facing context', function 
 
     $result = $this->action->handle($user);
 
-    expect($result['raw_data'])->not->toHaveKey('household_context');
+    expect($result['raw_data']['household'])->toHaveKey(
+        'summary',
+        'My husband Bataa is 38, has type 2 diabetes. Kids: Tana (12, peanut allergy).',
+    );
+
     expect($result['context'])
         ->not->toContain('HOUSEHOLD/FAMILY')
         ->not->toContain('Bataa');
@@ -210,7 +252,7 @@ it('never exposes date_of_birth or blood_type in raw_data or AI-facing context',
         ->not->toContain('A+');
 });
 
-it('exposes additional_goals in raw_data but never in AI-facing context', function (): void {
+it('includes additional goals in explicit profile prompt context', function (): void {
     $user = User::factory()->create();
     UserProfile::factory()->create([
         'user_id' => $user->id,
@@ -226,6 +268,31 @@ it('exposes additional_goals in raw_data but never in AI-facing context', functi
     expect($result['context'])
         ->toContain('Diet Type: keto')
         ->toContain('Recommended Macros: 5% carbs, 20% protein, 75% fat')
-        ->not->toContain('Additional Goals')
-        ->not->toContain('Build muscle and stay hydrated');
+        ->toContain('Additional Goals: Build muscle and stay hydrated');
+});
+
+it('builds a safety section for tool calls from allergies health conditions medications and household', function (): void {
+    $user = User::factory()->create();
+    $profile = UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'household_context' => 'My child has a peanut allergy.',
+    ]);
+    UserProfileAttribute::factory()->allergy('Peanuts')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+    UserProfileAttribute::factory()->healthCondition('Type 2 Diabetes')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+    UserProfileAttribute::factory()->medication('Metformin')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+
+    $result = resolve(BuildAiSafeUserProfile::class)->handle($user);
+
+    expect($result->section('safety'))
+        ->toHaveKeys(['allergies', 'health_conditions', 'medications', 'household'])
+        ->and($result->section('safety')['allergies'][0]['name'])->toBe('Peanuts')
+        ->and($result->section('safety')['health_conditions'][0]['name'])->toBe('Type 2 Diabetes')
+        ->and($result->section('safety')['medications'][0]['name'])->toBe('Metformin')
+        ->and($result->section('safety')['household']['summary'])->toBe('My child has a peanut allergy.');
 });

--- a/tests/Feature/Ai/MealPlanPromptBuilderTest.php
+++ b/tests/Feature/Ai/MealPlanPromptBuilderTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Ai\MealPlanPromptBuilder;
+use App\Enums\BloodType;
 use App\Enums\GlucoseReadingType;
 use App\Enums\GoalChoice;
 use App\Enums\Sex;
@@ -60,6 +61,34 @@ it('generates meal plan context for user with complete profile', function (): vo
         ->toContain('BMI')
         ->toContain('TDEE')
         ->toContain('Daily Calorie Target');
+});
+
+it('excludes unrelated profile fields and household free text from meal plan prompts', function (): void {
+    $user = User::factory()->create();
+    UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'age' => 30,
+        'date_of_birth' => '1996-04-04',
+        'blood_type' => BloodType::APositive,
+        'height' => 175,
+        'weight' => 80,
+        'sex' => Sex::Male,
+        'goal_choice' => GoalChoice::WeightLoss->value,
+        'household_context' => 'My husband Bataa likes extra spicy dinners.',
+    ]);
+
+    $builder = resolve(MealPlanPromptBuilder::class);
+    $result = $builder->handleForDay($user, 1, 7);
+
+    expect($result)
+        ->toContain('Age')
+        ->toContain('30 years')
+        ->not->toContain('Date of Birth')
+        ->not->toContain('1996-04-04')
+        ->not->toContain('Blood Type')
+        ->not->toContain('A+')
+        ->not->toContain('Bataa')
+        ->not->toContain('extra spicy dinners');
 });
 
 it('handles user with minimal profile data', function (): void {

--- a/tests/Unit/Ai/AgentBuilderTest.php
+++ b/tests/Unit/Ai/AgentBuilderTest.php
@@ -38,7 +38,7 @@ describe('build', function (): void {
             ->and($result['tools'])->toBeArray();
     });
 
-    it('includes profile context in instructions', function (): void {
+    it('does not include raw profile context in instructions', function (): void {
         $user = User::factory()->create();
         $payload = new AgentPayload(
             userId: $user->id,
@@ -48,7 +48,25 @@ describe('build', function (): void {
 
         $result = $this->builder->build($payload, $user);
 
-        expect($result['instructions'])->toContain('You are Altani');
+        expect($result['instructions'])
+            ->toContain('You are Altani')
+            ->not->toContain('USER PROFILE DATA');
+    });
+
+    it('instructs the agent to fetch profile context with the profile tool before personalizing advice', function (): void {
+        $user = User::factory()->create();
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: 'How much protein should I eat?',
+            mode: AgentMode::Ask,
+        );
+
+        $result = $this->builder->build($payload, $user);
+
+        expect($result['instructions'])
+            ->toContain('call `get_user_profile`')
+            ->toContain('smallest relevant section')
+            ->toContain('Use `all` only when a request spans multiple profile areas');
     });
 
     it('includes chat mode in instructions', function (): void {
@@ -156,5 +174,8 @@ it('handles null user gracefully', function (): void {
 
     $result = $this->builder->build($payload, null);
 
-    expect($result['instructions'])->toContain('No user context available');
+    expect($result['instructions'])
+        ->toContain('You are Altani')
+        ->not->toContain('No user context available')
+        ->not->toContain('USER PROFILE DATA');
 });

--- a/tests/Unit/Ai/Agents/AgentRunnerTest.php
+++ b/tests/Unit/Ai/Agents/AgentRunnerTest.php
@@ -38,7 +38,7 @@ describe('instructions', function (): void {
         expect($instructions)
             ->toContain('You are Altani, a comprehensive AI wellness assistant')
             ->toContain('CHAT MODE: ask')
-            ->toContain('USER PROFILE DATA');
+            ->toContain('call `get_user_profile`');
     });
 
     it('returns instructions with CreateMealPlan mode', function (): void {

--- a/tests/Unit/Ai/Agents/SingleMealAgentTest.php
+++ b/tests/Unit/Ai/Agents/SingleMealAgentTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Actions\GetUserProfileContextAction;
 use App\Ai\Agents\SingleMealAgent;
 use App\Ai\SingleMealPromptBuilder;
 use App\Enums\GoalChoice;
@@ -26,8 +25,7 @@ beforeEach(function (): void {
         'derived_activity_multiplier' => 1.5,
     ]);
 
-    $profileContext = new GetUserProfileContextAction;
-    $this->promptBuilder = new SingleMealPromptBuilder($profileContext);
+    $this->promptBuilder = resolve(SingleMealPromptBuilder::class);
     $this->agent = new SingleMealAgent($this->promptBuilder);
 });
 

--- a/tests/Unit/Ai/SingleMealPromptBuilderTest.php
+++ b/tests/Unit/Ai/SingleMealPromptBuilderTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Actions\GetUserProfileContextAction;
 use App\Ai\SingleMealPromptBuilder;
 use App\Enums\GoalChoice;
 use App\Enums\Sex;
@@ -13,8 +12,7 @@ covers(SingleMealPromptBuilder::class);
 beforeEach(function (): void {
     $this->user = User::factory()->create();
 
-    $this->action = new GetUserProfileContextAction;
-    $this->builder = new SingleMealPromptBuilder($this->action);
+    $this->builder = resolve(SingleMealPromptBuilder::class);
 });
 
 it('builds prompt with all parameters', function (): void {

--- a/tests/Unit/Ai/Tools/GetUserProfileTest.php
+++ b/tests/Unit/Ai/Tools/GetUserProfileTest.php
@@ -3,31 +3,26 @@
 declare(strict_types=1);
 
 use App\Ai\Tools\GetUserProfile;
-use App\Contracts\Actions\GetsUserProfileContext;
+use App\Enums\AllergySeverity;
+use App\Enums\BloodType;
+use App\Enums\GoalChoice;
+use App\Enums\Sex;
 use App\Models\User;
+use App\Models\UserProfile;
+use App\Models\UserProfileAttribute;
 use Laravel\Ai\Tools\Request;
 use Tests\Helpers\TestJsonSchema;
 
 covers(GetUserProfile::class);
 
 beforeEach(function (): void {
-    $this->action = new class implements GetsUserProfileContext
-    {
-        public array $contextData = [];
-
-        public function handle(User $user): array
-        {
-            return $this->contextData;
-        }
-    };
-
-    app()->instance(GetsUserProfileContext::class, $this->action);
-    $this->tool = new GetUserProfile();
+    $this->tool = resolve(GetUserProfile::class);
 });
 
 it('has correct name and description', function (): void {
     expect($this->tool->name())->toBe('get_user_profile')
-        ->and($this->tool->description())->toContain("Retrieve the current user's profile");
+        ->and($this->tool->description())->toContain("Retrieve the current user's AI-safe profile information")
+        ->and($this->tool->description())->toContain('smallest relevant section');
 });
 
 it('has valid schema', function (): void {
@@ -51,34 +46,42 @@ it('returns full profile when section is all', function (): void {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $this->action->contextData = [
+    UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'age' => 30,
+        'height' => 175,
+        'weight' => 80,
+        'sex' => Sex::Male,
+        'goal_choice' => GoalChoice::WeightLoss->value,
         'onboarding_completed' => true,
-        'missing_data' => [],
-        'context' => 'Formatted context',
-        'raw_data' => ['biometrics' => ['age' => 30]],
-    ];
+        'household_context' => 'Cooking for a child with a peanut allergy.',
+    ]);
 
     $request = new Request(['section' => 'all']);
     $result = $this->tool->handle($request);
     $json = json_decode((string) $result, true);
 
     expect($json)->toHaveKey('success', true)
-        ->and($json['profile'])->toHaveKey('biometrics');
+        ->and($json['profile'])->toHaveKeys([
+            'biometrics',
+            'dietary_preferences',
+            'goals',
+            'health_conditions',
+            'medications',
+            'household',
+        ])
+        ->and($json['profile']['biometrics'])->toHaveKey('age', 30)
+        ->and($json['profile']['household'])->toHaveKey('summary', 'Cooking for a child with a peanut allergy.');
 });
 
 it('returns specific section data', function (): void {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $this->action->contextData = [
-        'onboarding_completed' => true,
-        'missing_data' => [],
-        'context' => 'Formatted context',
-        'raw_data' => [
-            'biometrics' => ['age' => 30],
-            'goals' => ['primary_goal' => 'weight_loss'],
-        ],
-    ];
+    UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'age' => 30,
+    ]);
 
     $request = new Request(['section' => 'biometrics']);
     $result = $this->tool->handle($request);
@@ -89,41 +92,147 @@ it('returns specific section data', function (): void {
         ->and($json['data'])->toHaveKey('age', 30);
 });
 
+it('returns expanded profile sections individually', function (string $section, callable $assert): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $profile = UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'goal_choice' => GoalChoice::WeightLoss->value,
+        'household_context' => 'Cooking for two adults.',
+    ]);
+    UserProfileAttribute::factory()->dietaryPattern('Vegetarian')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+    UserProfileAttribute::factory()->healthCondition('Type 2 Diabetes')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+    UserProfileAttribute::factory()->medication('Metformin')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+
+    $result = $this->tool->handle(new Request(['section' => $section]));
+    $json = json_decode((string) $result, true);
+
+    expect($json)->toHaveKey('success', true)
+        ->and($json['section'])->toBe($section);
+
+    $assert($json['data']);
+})->with([
+    'dietary preferences' => [
+        'dietary_preferences',
+        fn (array $data) => expect($data[0])->toHaveKey('name', 'Vegetarian'),
+    ],
+    'goals' => [
+        'goals',
+        fn (array $data) => expect($data)->toHaveKey('primary_goal', 'weight_loss'),
+    ],
+    'health conditions' => [
+        'health_conditions',
+        fn (array $data) => expect($data[0])->toHaveKey('name', 'Type 2 Diabetes'),
+    ],
+    'medications' => [
+        'medications',
+        fn (array $data) => expect($data[0])->toHaveKey('name', 'Metformin'),
+    ],
+    'household' => [
+        'household',
+        fn (array $data) => expect($data)->toHaveKey('summary', 'Cooking for two adults.'),
+    ],
+]);
+
 it('handles missing section error', function (): void {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $this->action->contextData = [
-        'onboarding_completed' => true,
-        'missing_data' => [],
-        'context' => 'Formatted context',
-        'raw_data' => [
-            'biometrics' => ['age' => 30],
-        ],
-    ];
+    UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'age' => 30,
+    ]);
 
     $request = new Request(['section' => 'invalid_section']);
     $result = $this->tool->handle($request);
     $json = json_decode((string) $result, true);
 
     expect($json)->toHaveKey('error')
-        ->and($json['error'])->toContain("Section 'invalid_section' not found");
+        ->and($json['error'])->toContain("Section 'invalid_section' not found")
+        ->and($json['error'])->toContain('health_conditions');
 });
 
-it('handles error when raw data is missing', function (): void {
+it('returns safety section with allergies conditions medications and household constraints', function (): void {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $this->action->contextData = [
-        'onboarding_completed' => false,
-        'missing_data' => ['profile'],
-        'context' => 'No profile',
-        'raw_data' => null,
-    ];
+    $profile = UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'household_context' => 'My daughter has a peanut allergy.',
+    ]);
 
-    $request = new Request(['section' => 'biometrics']);
+    UserProfileAttribute::factory()->allergy('Peanuts', AllergySeverity::Severe)->create([
+        'user_profile_id' => $profile->id,
+        'notes' => 'Avoid cross-contact.',
+    ]);
+    UserProfileAttribute::factory()->healthCondition('Type 2 Diabetes')->create([
+        'user_profile_id' => $profile->id,
+        'metadata' => ['safety_level' => 'critical'],
+    ]);
+    UserProfileAttribute::factory()->medication('Metformin', [
+        'dosage' => '500mg',
+        'frequency' => 'twice daily',
+        'purpose' => 'Blood sugar control',
+    ])->create([
+        'user_profile_id' => $profile->id,
+    ]);
+
+    $request = new Request(['section' => 'safety']);
     $result = $this->tool->handle($request);
     $json = json_decode((string) $result, true);
 
-    expect($json)->toHaveKey('error', 'Profile data not available');
+    expect($json)->toHaveKey('success', true)
+        ->and($json['section'])->toBe('safety')
+        ->and($json['data'])->toHaveKeys(['allergies', 'health_conditions', 'medications', 'household'])
+        ->and($json['data']['allergies'][0])->toMatchArray([
+            'category' => 'allergy',
+            'name' => 'Peanuts',
+            'severity' => 'severe',
+            'notes' => 'Avoid cross-contact.',
+        ])
+        ->and($json['data']['health_conditions'][0])->toMatchArray([
+            'category' => 'health_condition',
+            'name' => 'Type 2 Diabetes',
+            'metadata' => ['safety_level' => 'critical'],
+        ])
+        ->and($json['data']['medications'][0])->toMatchArray([
+            'category' => 'medication',
+            'name' => 'Metformin',
+            'metadata' => [
+                'dosage' => '500mg',
+                'frequency' => 'twice daily',
+                'purpose' => 'Blood sugar control',
+            ],
+        ])
+        ->and($json['data']['household'])->toHaveKey('summary', 'My daughter has a peanut allergy.');
+});
+
+it('does not expose unrelated sensitive profile fields or model internals', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $profile = UserProfile::factory()->create([
+        'user_id' => $user->id,
+        'age' => 30,
+        'date_of_birth' => '1996-04-04',
+        'blood_type' => BloodType::APositive,
+    ]);
+    UserProfileAttribute::factory()->medication('Metformin')->create([
+        'user_profile_id' => $profile->id,
+    ]);
+
+    $result = $this->tool->handle(new Request(['section' => 'all']));
+    $json = json_decode((string) $result, true);
+
+    expect($json['profile']['biometrics'])
+        ->not->toHaveKeys(['date_of_birth', 'blood_type'])
+        ->and($json['profile']['medications'][0])
+        ->not->toHaveKeys(['id', 'user_profile_id', 'created_at', 'updated_at']);
 });

--- a/tests/Unit/Ai/Tools/GetUserProfileTest.php
+++ b/tests/Unit/Ai/Tools/GetUserProfileTest.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Models\UserProfile;
 use App\Models\UserProfileAttribute;
 use Laravel\Ai\Tools\Request;
+use Pest\Mixins\Expectation;
 use Tests\Helpers\TestJsonSchema;
 
 covers(GetUserProfile::class);
@@ -121,23 +122,23 @@ it('returns expanded profile sections individually', function (string $section, 
 })->with([
     'dietary preferences' => [
         'dietary_preferences',
-        fn (array $data) => expect($data[0])->toHaveKey('name', 'Vegetarian'),
+        fn (array $data): Expectation => expect($data[0])->toHaveKey('name', 'Vegetarian'),
     ],
     'goals' => [
         'goals',
-        fn (array $data) => expect($data)->toHaveKey('primary_goal', 'weight_loss'),
+        fn (array $data): Expectation => expect($data)->toHaveKey('primary_goal', 'weight_loss'),
     ],
     'health conditions' => [
         'health_conditions',
-        fn (array $data) => expect($data[0])->toHaveKey('name', 'Type 2 Diabetes'),
+        fn (array $data): Expectation => expect($data[0])->toHaveKey('name', 'Type 2 Diabetes'),
     ],
     'medications' => [
         'medications',
-        fn (array $data) => expect($data[0])->toHaveKey('name', 'Metformin'),
+        fn (array $data): Expectation => expect($data[0])->toHaveKey('name', 'Metformin'),
     ],
     'household' => [
         'household',
-        fn (array $data) => expect($data)->toHaveKey('summary', 'Cooking for two adults.'),
+        fn (array $data): Expectation => expect($data)->toHaveKey('summary', 'Cooking for two adults.'),
     ],
 ]);
 


### PR DESCRIPTION
- Remove reusable user profile data from Altani's main chat system prompt
- Add an AI-safe profile DTO/action plus prompt formatter for explicit generation workflows
- Expand `get_user_profile` sections to include biometrics, dietary preferences, goals, health conditions, medications, household, and safety
- Keep meal and single-meal generation deterministically personalized while excluding unrelated fields
- Remove unused mutable state from `MealPlanAgent`