### PR TITLE
refactor(ai): tighten orchestrator routing signals + add routing observability

### DIFF
--- a/app/Models/AiUsage.php
+++ b/app/Models/AiUsage.php
@@ -85,4 +85,22 @@ final class AiUsage extends Model
             $query->where('created_at', '<=', $endDate);
         }
     }
+
+    /**
+     * @param  Builder<AiUsage>  $query
+     */
+    #[Scope]
+    protected function byAgent(Builder $query, string $agent): void
+    {
+        $query->where('agent', $agent);
+    }
+
+    /**
+     * @param  Builder<AiUsage>  $query
+     */
+    #[Scope]
+    protected function specialist(Builder $query): void
+    {
+        $query->whereIn('agent', config()->array('plate.sub_agents', []));
+    }
 }

--- a/resources/views/ai/prompts/altani-static.blade.php
+++ b/resources/views/ai/prompts/altani-static.blade.php
@@ -47,6 +47,8 @@ You have three specialist sub-agents available as tools. They run in isolation a
 - **`health_specialist`** — reading the user's personal health data (metrics, trends, logs, summaries, goals), predicting a food's glucose spike, and Health Sync / Apple Health setup questions.
 - **`fitness_specialist`** — workout programs, wellness routines (sleep, stress, mobility, recovery), and fitness goals.
 
+Specialists have no access to `get_user_profile`. Before delegating any personalized task, call `get_user_profile` yourself for the sections the specialist will need, then inline those facts verbatim into the `task` — never tell a specialist to "check the user's profile," because it cannot. Inline the slice that matches the specialist: for `nutrition_specialist`, allergies, dietary patterns, and any calorie or macro target; for `fitness_specialist`, relevant biometrics, fitness goals, and equipment or experience constraints; for `health_specialist`, the metric in question plus any relevant conditions or medications.
+
 Writes and durable profile updates stay with you — never delegate them. Call `log_health_entry`, `update_user_biometrics`, `update_user_profile_attributes`, and `update_household_context` yourself, and build multi-day plans with `create_meal_plan` yourself. You hold the conversation context needed to record exact values, units, and timing, and specialists cannot perform these writes.
 
 When relaying a specialist's answer about personal data, relay only what it reported — never add or invent numbers. If a specialist's result begins with `Agent failed:`, treat it as a failed tool: briefly tell the user you couldn't complete that part and suggest they try again — never fabricate the answer it was supposed to return.

--- a/resources/views/ai/prompts/altani-static.blade.php
+++ b/resources/views/ai/prompts/altani-static.blade.php
@@ -17,9 +17,9 @@ You celebrate progress without being sycophantic. You give hard truths with comp
 
 ## Your Expertise
 
-- **Nutrition**: meal planning, dietary advice, nutritional analysis, glucose impact prediction
+- **Nutrition**: meal planning, dietary advice, nutritional analysis
 - **Fitness**: workout programs, strength training, cardiovascular plans, form guidance
-- **Health**: sleep optimization, stress management, habit formation, lifestyle advice
+- **Health**: habit formation, lifestyle advice, and quick sleep and stress tips (structured multi-step wellness routines are delegated to `fitness_specialist`)
 - **Image Analysis**: analyze food photos for nutritional breakdown
 
 ---
@@ -47,9 +47,9 @@ You have three specialist sub-agents available as tools. They run in isolation a
 - **`health_specialist`** — reading the user's personal health data (metrics, trends, logs, summaries, goals), predicting a food's glucose spike, and Health Sync / Apple Health setup questions.
 - **`fitness_specialist`** — workout programs, wellness routines (sleep, stress, mobility, recovery), and fitness goals.
 
-To LOG a health measurement, call `log_health_entry` yourself — do not delegate writes; you hold the conversation context needed to record the exact value, unit, and timing.
+Writes and durable profile updates stay with you — never delegate them. Call `log_health_entry`, `update_user_biometrics`, `update_user_profile_attributes`, and `update_household_context` yourself, and build multi-day plans with `create_meal_plan` yourself. You hold the conversation context needed to record exact values, units, and timing, and specialists cannot perform these writes.
 
-When relaying a specialist's answer about personal data, relay only what it reported — never add or invent numbers. If a specialist's result begins with `Agent failed:`, treat it as a failed tool: briefly tell the user you couldn't complete that part and suggest they try again — never fabricate the answer it was supposed to return. If a specialist's result begins with `Agent failed:`, treat it as a failed tool: briefly tell the user you couldn't complete that part and suggest they try again — never fabricate the answer it was supposed to return.
+When relaying a specialist's answer about personal data, relay only what it reported — never add or invent numbers. If a specialist's result begins with `Agent failed:`, treat it as a failed tool: briefly tell the user you couldn't complete that part and suggest they try again — never fabricate the answer it was supposed to return.
 
 ---
 

--- a/tests/Unit/Ai/AgentBuilderTest.php
+++ b/tests/Unit/Ai/AgentBuilderTest.php
@@ -120,6 +120,21 @@ describe('build', function (): void {
             ->toContain('create_meal_plan');
     });
 
+    it('instructs the orchestrator to inline profile context into the delegated task', function (): void {
+        $user = User::factory()->create();
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: 'Hello',
+            mode: AgentMode::Ask,
+        );
+
+        $result = $this->builder->build($payload, $user);
+
+        expect($result['instructions'])
+            ->toContain('Specialists have no access to `get_user_profile`')
+            ->toContain('inline those facts verbatim into the `task`');
+    });
+
     it('does not claim a delegated domain in its own expertise banner', function (): void {
         $user = User::factory()->create();
         $payload = new AgentPayload(

--- a/tests/Unit/Ai/AgentBuilderTest.php
+++ b/tests/Unit/Ai/AgentBuilderTest.php
@@ -89,6 +89,52 @@ describe('build', function (): void {
             ->toContain('fitness_specialist');
     });
 
+    it('states the specialist failure-handling rule exactly once', function (): void {
+        $user = User::factory()->create();
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: 'Hello',
+            mode: AgentMode::Ask,
+        );
+
+        $result = $this->builder->build($payload, $user);
+
+        expect(mb_substr_count($result['instructions'], 'treat it as a failed tool'))->toBe(1);
+    });
+
+    it('keeps every durable write and meal-plan creation with the orchestrator', function (): void {
+        $user = User::factory()->create();
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: 'Hello',
+            mode: AgentMode::Ask,
+        );
+
+        $result = $this->builder->build($payload, $user);
+
+        expect($result['instructions'])
+            ->toContain('log_health_entry')
+            ->toContain('update_user_biometrics')
+            ->toContain('update_user_profile_attributes')
+            ->toContain('update_household_context')
+            ->toContain('create_meal_plan');
+    });
+
+    it('does not claim a delegated domain in its own expertise banner', function (): void {
+        $user = User::factory()->create();
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: 'Hello',
+            mode: AgentMode::Ask,
+        );
+
+        $result = $this->builder->build($payload, $user);
+
+        expect($result['instructions'])
+            ->not->toContain('glucose impact prediction')
+            ->toContain('health_specialist');
+    });
+
     it('includes chat mode in instructions', function (): void {
         $user = User::factory()->create();
         $payload = new AgentPayload(

--- a/tests/Unit/Ai/Agents/SpecialistAgentsTest.php
+++ b/tests/Unit/Ai/Agents/SpecialistAgentsTest.php
@@ -105,3 +105,19 @@ it('can be faked and prompted directly as an isolated sub-agent', function (stri
 
     $class::assertPrompted('Handle this delegated task.');
 })->with('specialists');
+
+dataset('specialist scope keywords', [
+    'nutrition' => [NutritionSpecialist::class, ['single meals', 'create_meal_plan']],
+    'health' => [HealthSpecialist::class, ['health data', 'glucose']],
+    'fitness' => [FitnessSpecialist::class, ['workout', 'wellness']],
+]);
+
+it('keeps its routing scope and isolation marker in the description as the single source of truth', function (string $class, array $keywords): void {
+    $description = resolve($class)->description();
+
+    expect($description)->toContain('cannot see the chat history');
+
+    foreach ($keywords as $keyword) {
+        expect($description)->toContain($keyword);
+    }
+})->with('specialist scope keywords');

--- a/tests/Unit/Ai/Tools/GetUserProfileTest.php
+++ b/tests/Unit/Ai/Tools/GetUserProfileTest.php
@@ -11,7 +11,7 @@ use App\Models\User;
 use App\Models\UserProfile;
 use App\Models\UserProfileAttribute;
 use Laravel\Ai\Tools\Request;
-use Pest\Mixins\Expectation;
+use Pest\Expectation;
 use Tests\Helpers\TestJsonSchema;
 
 covers(GetUserProfile::class);

--- a/tests/Unit/Models/AiUsageTest.php
+++ b/tests/Unit/Models/AiUsageTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Ai\Agents\AgentRunner;
+use App\Ai\Agents\HealthSpecialist;
+use App\Ai\Agents\NutritionSpecialist;
 use App\Models\AiUsage;
 
 covers(AiUsage::class);
@@ -39,4 +42,21 @@ it('casts prompt_tokens to integer', function (): void {
     $aiUsage->prompt_tokens = '1000';
 
     expect($aiUsage->prompt_tokens)->toBeInt();
+});
+
+it('filters usage rows to a single agent FQCN', function (): void {
+    AiUsage::factory()->create(['agent' => NutritionSpecialist::class]);
+    AiUsage::factory()->create(['agent' => HealthSpecialist::class]);
+    AiUsage::factory()->create(['agent' => AgentRunner::class]);
+
+    expect(AiUsage::query()->byAgent(NutritionSpecialist::class)->count())->toBe(1)
+        ->and(AiUsage::query()->byAgent(AgentRunner::class)->count())->toBe(1);
+});
+
+it('filters usage rows to delegated specialists only', function (): void {
+    AiUsage::factory()->create(['agent' => NutritionSpecialist::class]);
+    AiUsage::factory()->create(['agent' => HealthSpecialist::class]);
+    AiUsage::factory()->create(['agent' => AgentRunner::class]);
+
+    expect(AiUsage::query()->specialist()->count())->toBe(2);
 });


### PR DESCRIPTION
…

Incremental routing-quality cleanup of the Altani chat orchestration. No name()/promptView()/tool-name changes (stability contract for prompts + acara-core preserved).

- Remove verbatim-duplicated 'Agent failed:' failure-handling sentence in altani-static prompt
- Generalize the orchestrator-only write carve-out: all durable profile writes + create_meal_plan stay orchestrator-side (closes silent lost-write mis-route when delegating to a specialist)
- Reconcile 'Your Expertise' banner with the delegation table: drop delegated 'glucose impact prediction' from Nutrition; clarify structured wellness routines route to fitness_specialist
- Add AiUsage::byAgent()/specialist() scopes over the already-persisted agent FQCN for routing observability (no migration, no new subsystem)
- Add drift-guard test pinning each specialist description() as the single source of routing-scope truth

Tests: AgentBuilderTest, SpecialistAgentsTest, AiUsageTest all green.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
