### PR TITLE
fix(chat): require a nutrition estimate when logging food

### DIFF
--- a/app/Actions/Approvals/ApproveAgentApproval.php
+++ b/app/Actions/Approvals/ApproveAgentApproval.php
@@ -32,7 +32,7 @@ final readonly class ApproveAgentApproval
                 'resolved_at' => now(),
             ]);
 
-            dispatch(new ExecuteApprovalJob($locked->id));
+            dispatch(new ExecuteApprovalJob($locked->id))->afterCommit();
         });
 
         return $approval->fresh() ?? $approval;

--- a/app/Ai/Tools/LogHealthEntry.php
+++ b/app/Ai/Tools/LogHealthEntry.php
@@ -42,7 +42,7 @@ final readonly class LogHealthEntry implements Tool
 
     public function description(): string
     {
-        return 'Log a health entry for the current user. Use this when the user reports a health measurement like food intake, glucose reading, weight, blood pressure, insulin dose, medication, or exercise. Extract the relevant data from the user message and call this tool to save it.';
+        return 'Log a health entry for the current user. Use this when the user reports a health measurement like food intake, glucose reading, weight, blood pressure, insulin dose, medication, or exercise. Extract the relevant data from the user message and call this tool to save it. When logging food, always estimate calories and macronutrients (carbs, protein, fat) from the description — never log a food entry with no nutrition values.';
     }
 
     public function handle(Request $request): string
@@ -69,6 +69,15 @@ final readonly class LogHealthEntry implements Tool
                 'field' => 'glucose_unit',
                 'message' => 'Your glucose value looks like mmol/L. Please confirm whether it is mg/dL or mmol/L.',
                 'allowed_values' => ['mg/dL', 'mmol/L'],
+            ]);
+        }
+
+        if ($this->requiresFoodEstimate($healthData)) {
+            return (string) json_encode([
+                'error' => 'Estimate the nutrition for this food before logging.',
+                'requires_estimate' => true,
+                'field' => 'calories',
+                'message' => 'Food entries must include your best estimate of calories (and carbs, protein, and fat when relevant). Estimate from the food described — do not ask the user for exact numbers — then call log_health_entry again.',
             ]);
         }
 
@@ -123,7 +132,7 @@ final readonly class LogHealthEntry implements Tool
             'fat_grams' => $schema->number()->required()->nullable()
                 ->description('Fat intake in grams (can be decimal like 12.5).'),
             'calories' => $schema->integer()->required()->nullable()
-                ->description('Total calories.'),
+                ->description('Total calories. For food entries, always provide your best estimate (e.g. two pancakes ≈ 175 kcal) even when the user does not state it.'),
             'notes' => $schema->string()->required()->nullable()
                 ->description('Food name or additional notes.'),
             'insulin_units' => $schema->number()->required()->nullable()
@@ -213,5 +222,14 @@ final readonly class LogHealthEntry implements Tool
         }
 
         return $healthData->glucoseValue > 0 && $healthData->glucoseValue < 20;
+    }
+
+    private function requiresFoodEstimate(HealthLogData $healthData): bool
+    {
+        return $healthData->logType === HealthEntryType::Food
+            && $healthData->calories === null
+            && $healthData->carbsGrams === null
+            && $healthData->proteinGrams === null
+            && $healthData->fatGrams === null;
     }
 }

--- a/app/Jobs/ExecuteApprovalJob.php
+++ b/app/Jobs/ExecuteApprovalJob.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
 use Throwable;
 
 #[MaxExceptions(3)]
-#[Timeout(120)]
+#[Timeout(60)]
 final class ExecuteApprovalJob implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;

--- a/app/Listeners/NotifyTelegramOfApprovalOutcome.php
+++ b/app/Listeners/NotifyTelegramOfApprovalOutcome.php
@@ -44,7 +44,11 @@ final class NotifyTelegramOfApprovalOutcome implements ShouldQueue
             return;
         }
 
-        $chat->message($message)->dispatch();
+        if (! $approval->claimNotification()) {
+            return;
+        }
+
+        $chat->message($message)->send();
     }
 
     private function outcomeMessage(AgentApproval $approval): ?string

--- a/app/Models/AgentApproval.php
+++ b/app/Models/AgentApproval.php
@@ -29,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property CarbonInterface $expires_at
  * @property CarbonInterface|null $resolved_at
  * @property CarbonInterface|null $executed_at
+ * @property CarbonInterface|null $notified_at
  * @property CarbonInterface $created_at
  * @property CarbonInterface $updated_at
  * @property-read User $user
@@ -51,6 +52,7 @@ final class AgentApproval extends Model
             'expires_at' => 'datetime',
             'resolved_at' => 'datetime',
             'executed_at' => 'datetime',
+            'notified_at' => 'datetime',
         ];
     }
 
@@ -63,6 +65,14 @@ final class AgentApproval extends Model
             canReject: $this->status->canReject(),
             error: $this->error,
         );
+    }
+
+    public function claimNotification(): bool
+    {
+        return self::query()
+            ->whereKey($this->getKey())
+            ->whereNull('notified_at')
+            ->update(['notified_at' => now()]) > 0;
     }
 
     /**

--- a/database/migrations/2026_06_02_015405_add_notified_at_to_agent_approvals_table.php
+++ b/database/migrations/2026_06_02_015405_add_notified_at_to_agent_approvals_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_approvals', function (Blueprint $table): void {
+            $table->timestamp('notified_at')->nullable()->after('executed_at');
+        });
+    }
+};

--- a/docs/telegram-message-keyboards-ai-agent-guide.md
+++ b/docs/telegram-message-keyboards-ai-agent-guide.md
@@ -1,0 +1,285 @@
+# Telegram Message Keyboards guideline
+
+This guide explains how to use Telegraph message keyboards as the action surface for a Laravel AI agent.
+
+Telegraph message keyboards are Telegram inline keyboards attached to bot messages. For an AI agent, they are best used as a controlled bridge between model-generated intent and Laravel-owned execution. The agent may propose an action, but Laravel should decide which buttons are available, which callback action is allowed, and which server-side record the button references.
+
+## Mental Model
+
+Use keyboards when the user or operator needs to choose from a bounded set of actions:
+
+- Approve or reject an agent tool call.
+- Pick one of several model-suggested next steps.
+- Open a review page.
+- Copy a generated token, invite link, or reference code.
+- Launch a Telegram Web App for richer interaction.
+
+Do not put raw LLM output, sensitive data, or full tool parameters into callback payloads. Store the real data in your database and pass compact identifiers such as `approval_id`, `run_id`, or `message_id`.
+
+## Send a Message With a Keyboard
+
+```php
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Keyboard\Button;
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+Telegraph::message('The agent wants to process this refund. Approve?')
+    ->keyboard(Keyboard::make()->buttons([
+        Button::make('Approve')->action('approveToolCall')->param('approval_id', '42'),
+        Button::make('Reject')->action('rejectToolCall')->param('approval_id', '42'),
+        Button::make('Open request')->url('https://app.test/approvals/42'),
+    ]))
+    ->send();
+```
+
+The `action()` value maps to a public method on your custom Telegraph webhook handler. The `param()` values are delivered as callback data.
+
+## Build a Keyboard With a Closure
+
+Closure syntax is useful when the keyboard is assembled dynamically.
+
+```php
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+Telegraph::message('Choose the next action')
+    ->keyboard(function (Keyboard $keyboard): Keyboard {
+        return $keyboard
+            ->button('Approve')->action('approveToolCall')->param('id', '42')
+            ->button('Reject')->action('rejectToolCall')->param('id', '42')
+            ->button('View')->url('https://app.test/agent-runs/42');
+    })
+    ->send();
+```
+
+## Button Types
+
+### Callback Buttons
+
+Use callback buttons for application actions that Laravel must handle.
+
+```php
+Button::make('Approve')->action('approveToolCall')->param('id', '42');
+```
+
+Good uses:
+
+- Approving a pending AI tool call.
+- Rejecting a proposed action.
+- Retrying an agent run.
+- Marking a notification or task as resolved.
+
+### URL Buttons
+
+Use URL buttons for navigation.
+
+```php
+Button::make('Open dashboard')->url('https://app.test/dashboard');
+```
+
+Good uses:
+
+- Opening a review screen.
+- Linking to a customer profile.
+- Sending the user to documentation or a billing page.
+
+### Web App Buttons
+
+Use Web App buttons when the interaction needs a richer Telegram Web App.
+
+```php
+Button::make('Open review app')->webApp('https://app.test/telegram/review');
+```
+
+Good uses:
+
+- Multi-field review flows.
+- Human-in-the-loop approval screens.
+- Workflows that are too complex for a few inline buttons.
+
+### Login URL Buttons
+
+Use Login URL buttons for Telegram login widget flows.
+
+```php
+Button::make('Login')->loginUrl('https://app.test/auth/telegram');
+```
+
+### Switch Inline Query Buttons
+
+Use inline query buttons when users should insert a bot query into another chat or the current chat.
+
+```php
+Button::make('Share result')->switchInlineQuery('agent-summary-42');
+Button::make('Use here')->switchInlineQuery('agent-summary-42')->currentChat();
+```
+
+### Copy Text Buttons
+
+Use copy buttons for values users need to paste somewhere else.
+
+```php
+Button::make('Copy invite link')->copyText('https://t.me/joinchat/ABC123');
+Button::make('Copy promo code')->copyText('SAVE20OFF');
+Button::make('Copy support email')->copyText('support@example.com');
+```
+
+## Layout
+
+Telegraph normally places one button per row. Approval flows are easier to scan when competing actions sit on the same row.
+
+```php
+$keyboard = Keyboard::make()
+    ->row([
+        Button::make('Approve')->action('approveToolCall')->param('id', '42'),
+        Button::make('Reject')->action('rejectToolCall')->param('id', '42'),
+    ])
+    ->row([
+        Button::make('Open details')->url('https://app.test/approvals/42'),
+    ]);
+```
+
+You can also use button widths:
+
+```php
+$keyboard = Keyboard::make()
+    ->button('Approve')->action('approveToolCall')->param('id', '42')->width(0.5)
+    ->button('Reject')->action('rejectToolCall')->param('id', '42')->width(0.5)
+    ->button('Details')->url('https://app.test/approvals/42');
+```
+
+For repeated options, use `chunk()`:
+
+```php
+$keyboard = Keyboard::make()
+    ->button('A')->action('chooseOption')->param('value', 'a')
+    ->button('B')->action('chooseOption')->param('value', 'b')
+    ->button('C')->action('chooseOption')->param('value', 'c')
+    ->chunk(2);
+```
+
+## Conditional Buttons
+
+Use `when()` to show buttons only when the current user or operator is allowed to perform the action.
+
+```php
+Keyboard::make()
+    ->button('Dismiss')->action('dismissToolCall')->param('id', '42')->width(0.5)
+    ->when(
+        $userCanApprove,
+        fn (Keyboard $keyboard): Keyboard => $keyboard
+            ->button('Approve')->action('approveToolCall')->param('id', '42')->width(0.5)
+    );
+```
+
+Authorization still belongs on the server. Conditional buttons improve the UI, but webhook handlers must re-check permissions.
+
+## Handle Callback Buttons
+
+Callback buttons are handled by public methods on a Telegraph webhook handler.
+
+```php
+namespace App\Http\Webhooks;
+
+use App\Actions\ApproveAgentToolCall;
+use App\Actions\RejectAgentToolCall;
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+
+final class AgentWebhookHandler extends WebhookHandler
+{
+    public function approveToolCall(ApproveAgentToolCall $approveAgentToolCall): void
+    {
+        $approvalId = (int) $this->data->get('id');
+
+        $approveAgentToolCall->handle($approvalId);
+
+        $this->reply('Approved. The agent action is queued.');
+        $this->deleteKeyboard();
+    }
+
+    public function rejectToolCall(RejectAgentToolCall $rejectAgentToolCall): void
+    {
+        $approvalId = (int) $this->data->get('id');
+
+        $rejectAgentToolCall->handle($approvalId);
+
+        $this->reply('Rejected.');
+        $this->deleteKeyboard();
+    }
+}
+```
+
+Register the handler in `config/telegraph.php`:
+
+```php
+'webhook' => [
+    'handler' => App\Http\Webhooks\AgentWebhookHandler::class,
+],
+```
+
+## Replace or Delete a Keyboard
+
+After a callback is handled, remove or replace the keyboard so stale buttons cannot be clicked again.
+
+```php
+$this->deleteKeyboard();
+```
+
+Or replace it with a reduced keyboard:
+
+```php
+$newKeyboard = $this->originalKeyboard->deleteButton('Approve');
+
+$this->replaceKeyboard($newKeyboard);
+```
+
+You can also update a keyboard by message ID:
+
+```php
+Telegraph::replaceKeyboard(
+    messageId: 1568794,
+    newKeyboard: Keyboard::make()->buttons([
+        Button::make('Open details')->url('https://app.test/approvals/42'),
+    ]),
+)->send();
+```
+
+To remove a keyboard by message ID:
+
+```php
+Telegraph::deleteKeyboard(messageId: 1568794)->send();
+```
+
+## AI Agent Approval Pattern
+
+Use this pattern for high-risk tool calls:
+
+1. The AI agent proposes an action.
+2. Laravel validates the proposed action and parameters.
+3. Laravel creates a pending approval record.
+4. Telegraph sends an operator message with approval buttons.
+5. The operator clicks approve or reject.
+6. The webhook handler loads the pending approval record.
+7. Laravel re-authorizes the action.
+8. Laravel marks the record resolved and dispatches execution through an Action or queued job.
+9. The webhook replies to Telegram and deletes or replaces the keyboard.
+
+The important boundary is that the Telegram button approves a server-side record. It should not execute arbitrary model text or trust callback payloads as the source of truth.
+
+## Production Rules
+
+- Keep callback payloads small and non-sensitive.
+- Use stable callback action names such as `approveToolCall`, `rejectToolCall`, and `retryAgentRun`.
+- Store full agent tool parameters in your database.
+- Validate and authorize again inside the webhook handler.
+- Make approval and execution idempotent.
+- Delete or replace keyboards after successful callbacks.
+- Use queued jobs for slow or external side effects.
+- Log approval decisions for auditability.
+- Prefer URL or Web App buttons for complex review workflows.
+
+## References
+
+- Telegraph Message Keyboards: https://docs.defstudio.it/telegraph/v1/features/keyboards
+- Telegraph Callback Data: https://docs.defstudio.it/telegraph/v1/webhooks/callback-data
+- Telegraph Webhook Request Types: https://docs.defstudio.it/telegraph/v1/webhooks/webhook-request-types
+- Telegraph Keyboard Interaction: https://docs.defstudio.it/telegraph/v1/webhooks/keyboard-interaction

--- a/tests/Unit/Ai/Tools/LogHealthEntryTest.php
+++ b/tests/Unit/Ai/Tools/LogHealthEntryTest.php
@@ -163,17 +163,33 @@ it('logs an exercise entry', function (): void {
         ->and($sample->metadata['exercise_type'])->toBe('walking');
 });
 
-it('logs a food entry with only notes and no macros', function (): void {
+it('asks for a nutrition estimate when a food entry has no calories or macros', function (): void {
     $user = User::factory()->create();
     Auth::login($user);
 
     $tool = resolve(LogHealthEntry::class);
-    $request = new Request([
+    $result = json_decode($tool->handle(new Request([
         'log_type' => 'food',
         'notes' => 'apple',
-    ]);
+    ])), true);
 
-    $result = json_decode($tool->handle($request), true);
+    expect($result)
+        ->toHaveKey('requires_estimate', true)
+        ->toHaveKey('field', 'calories')
+        ->and(HealthSyncSample::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('logs a food entry with an estimated calorie count', function (): void {
+    $user = User::factory()->create();
+    Auth::login($user);
+
+    $tool = resolve(LogHealthEntry::class);
+    $result = json_decode($tool->handle(new Request([
+        'log_type' => 'food',
+        'calories' => 175,
+        'carbs_grams' => 30,
+        'notes' => 'Two pancakes',
+    ])), true);
 
     expect($result)->toHaveKey('success', true);
 
@@ -182,8 +198,8 @@ it('logs a food entry with only notes and no macros', function (): void {
         ->where('type_identifier', HealthSyncType::DietaryEnergy->value)
         ->first();
 
-    expect($sample->value)->toBe(0.0)
-        ->and($sample->notes)->toBe('apple');
+    expect($sample->value)->toBe(175.0)
+        ->and($sample->notes)->toBe('Two pancakes');
 });
 
 it('returns error when vitals entry has no data', function (): void {

--- a/tests/Unit/Listeners/NotifyTelegramOfApprovalOutcomeTest.php
+++ b/tests/Unit/Listeners/NotifyTelegramOfApprovalOutcomeTest.php
@@ -97,3 +97,43 @@ it('does nothing for a still-pending approval', function (): void {
 
     Telegraph::assertNothingSent();
 });
+
+it('does not send again when the approval was already notified', function (): void {
+    $user = User::factory()->create();
+    linkUserToTelegram($this, $user);
+
+    $approval = AgentApproval::factory()->telegram()->executed()->create([
+        'user_id' => $user->id,
+        'summary' => 'Glucose 140 mg/dL (fasting)',
+        'notified_at' => now(),
+    ]);
+
+    notify($approval->id);
+
+    Telegraph::assertNothingSent();
+});
+
+it('notifies exactly once when the resolved event fires twice', function (AgentApprovalStatus $status, string $expected): void {
+    $user = User::factory()->create();
+    linkUserToTelegram($this, $user);
+
+    $approval = AgentApproval::factory()->telegram()->create([
+        'user_id' => $user->id,
+        'status' => $status,
+        'summary' => 'Glucose 140 mg/dL (fasting)',
+    ]);
+
+    notify($approval->id);
+
+    Telegraph::assertSent($expected, false);
+
+    $firstNotifiedAt = $approval->fresh()->notified_at;
+    expect($firstNotifiedAt)->not->toBeNull();
+
+    notify($approval->id);
+
+    expect($approval->fresh()->notified_at->equalTo($firstNotifiedAt))->toBeTrue();
+})->with([
+    'executed' => [AgentApprovalStatus::Executed, 'Saved: Glucose 140 mg/dL (fasting)'],
+    'failed' => [AgentApprovalStatus::Failed, 'save that entry'],
+]);


### PR DESCRIPTION
## Bug

Manual HITL testing surfaced a data-quality bug: logging **"I had two pancakes"** saved a single `dietaryEnergy 0.0000 kcal` sample with no macros — a nutritionally empty entry. The same tool, on the same model, logged **"250 g steak at dinner"** with full nutrition (650 kcal, 65g protein, 45g fat, 0g carbs). The difference was purely whether the model bothered to estimate — nothing required it to, so empty food logs slipped through (all channels).

Root cause: `HealthLogData::toFoodSamples()` writes a fallback `DietaryEnergy = 0` row when calories *and* all macros are null, and neither the tool description nor the Altani prompt told the model to estimate nutrition for food.

## Fix

- **Descriptions** — the tool description and `calories` field now instruct the model to always estimate calories + macros for food.
- **Guard** — new `requiresFoodEstimate` (mirrors the existing `requiresGlucoseUnitClarification`) rejects a food entry with **no** calories/carbs/protein/fat, returning a `requires_estimate` error so the model estimates and retries *before* the entry reaches the approval card. Invisible to the user; runs on every channel.

Only truly-empty food is rejected — any nutrition value present (the steak case, a carbs-only entry, etc.) passes through unchanged.

## Tests

- Flipped the old "food with only notes" test (which asserted the 0-kcal behavior) to assert the guard; added a food-with-calories test.
- `vendor/bin/pint` clean; 50 tool + approval tests pass.