### PR TITLE
Durable, resumable AI chat streaming

### DIFF
--- a/app/Actions/BuildAssistantAgentAction.php
+++ b/app/Actions/BuildAssistantAgentAction.php
@@ -4,64 +4,21 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\Ai\AgentPayload;
-use App\Ai\Agents\AgentRunner;
-use App\Contracts\Memory\DispatchesMemoryExtraction;
 use App\Http\Requests\StreamChatRequest;
-use App\Jobs\SummarizeConversationJob;
-use App\Models\Conversation;
 use App\Models\User;
-use App\Utilities\ConfigHelper;
-use Illuminate\Support\Facades\Context;
-use Laravel\Ai\Responses\StreamableAgentResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class BuildAssistantAgentAction
 {
     public function __construct(
-        private AgentRunner $agentRunner,
-        private DispatchesMemoryExtraction $memoryExtraction,
+        private StartAgentStreamRunAction $startRun,
+        private ReplayAgentStreamAction $replay,
     ) {}
 
-    public function handle(StreamChatRequest $request, User $user, string $conversationId, string $channel = 'web'): StreamableAgentResponse
+    public function handle(StreamChatRequest $request, User $user, string $conversationId, string $channel = 'web'): StreamedResponse
     {
-        Context::add('chat.channel', $channel);
-        Context::add('chat.conversation_id', $conversationId);
+        $run = $this->startRun->handle($request, $user, $conversationId, $channel);
 
-        $agentPayload = new AgentPayload(
-            userId: $user->id,
-            message: $request->userMessage(),
-            images: $request->userAttachments(),
-            modelName: $request->modelName(),
-            conversationId: $conversationId,
-        );
-
-        $this->dispatchSummarizationIfNeeded($conversationId);
-        $this->memoryExtraction->dispatchIfEligible($user->id);
-
-        return $this->agentRunner->runWithConversation($agentPayload, $user, $conversationId);
-    }
-
-    private function dispatchSummarizationIfNeeded(string $conversationId): void
-    {
-        $conversation = Conversation::query()->find($conversationId);
-
-        if (! $conversation instanceof Conversation) {
-            return;
-        }
-
-        if ($conversation->summarization_dispatched_at?->isAfter(now()->subMinutes(5))) {
-            return;
-        }
-
-        $buffer = ConfigHelper::int('altani.summarization.buffer', 25);
-        $threshold = ConfigHelper::int('altani.summarization.threshold', 20);
-
-        if ($conversation->messages()->count() < ($buffer + $threshold)) {
-            return;
-        }
-
-        $conversation->update(['summarization_dispatched_at' => now()]);
-
-        dispatch(new SummarizeConversationJob($conversation));
+        return $this->replay->handle($run->id);
     }
 }

--- a/app/Actions/ReplayAgentStreamAction.php
+++ b/app/Actions/ReplayAgentStreamAction.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\Streaming\ManagesStreamChunks;
+use App\Enums\AgentStreamStatus;
+use App\Models\AgentStreamRun;
+use App\Support\Streaming\VercelChunkStreamer;
+use App\Utilities\ConfigHelper;
+use Illuminate\Support\Sleep;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final readonly class ReplayAgentStreamAction
+{
+    public function __construct(private ManagesStreamChunks $chunks) {}
+
+    public function isResumable(AgentStreamRun $run, int $fromSequence = -1): bool
+    {
+        if ($run->expires_at->isPast()) {
+            return false;
+        }
+
+        if ($run->status->isTerminal()) {
+            return $this->chunks->latestSequence($run->id) > $fromSequence;
+        }
+
+        return true;
+    }
+
+    public function handle(string $runId, int $fromSequence = -1): StreamedResponse
+    {
+        return response()->stream(function () use ($runId, $fromSequence) {
+            $streamer = new VercelChunkStreamer;
+            $cursor = $fromSequence;
+
+            $pollMicros = ConfigHelper::int('altani.stream.poll_interval_ms', 400) * 1000;
+            $deadline = now()->addSeconds(ConfigHelper::int('altani.stream.max_tail_seconds', 150));
+            $stallDeadline = now()->addSeconds(ConfigHelper::int('altani.stream.stall_seconds', 20));
+
+            while (true) {
+                foreach ($this->chunks->chunksAfter($runId, $cursor) as $chunk) {
+                    $cursor = $chunk->sequence;
+
+                    if (($line = $streamer->line($chunk->vercel)) !== null) {
+                        yield $line;
+                    }
+                }
+
+                if (connection_aborted() !== 0) {
+                    return;
+                }
+
+                $run = AgentStreamRun::query()->find($runId);
+
+                if (! $run instanceof AgentStreamRun) {
+                    break;
+                }
+
+                if ($run->status->isTerminal()) {
+                    foreach ($this->chunks->chunksAfter($runId, $cursor) as $chunk) {
+                        $cursor = $chunk->sequence;
+
+                        if (($line = $streamer->line($chunk->vercel)) !== null) {
+                            yield $line;
+                        }
+                    }
+
+                    break;
+                }
+
+                $now = now();
+
+                if ($now->greaterThan($deadline)) {
+                    break;
+                }
+
+                if ($run->status === AgentStreamStatus::Queued && $now->greaterThan($stallDeadline)) {
+                    break;
+                }
+
+                Sleep::usleep($pollMicros);
+            }
+
+            yield $streamer->trailer();
+        }, headers: [
+            'Cache-Control' => 'no-cache, no-transform',
+            'Content-Type' => 'text/event-stream',
+            'x-vercel-ai-ui-message-stream' => 'v1',
+        ]);
+    }
+}

--- a/app/Actions/StartAgentStreamRunAction.php
+++ b/app/Actions/StartAgentStreamRunAction.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Actions\Billing\EnforceAiUsageLimit;
+use App\Ai\AgentPayload;
+use App\Ai\Agents\AgentRunner;
+use App\Contracts\Memory\DispatchesMemoryExtraction;
+use App\Enums\AgentStreamStatus;
+use App\Http\Requests\StreamChatRequest;
+use App\Jobs\StreamAgentRunJob;
+use App\Jobs\SummarizeConversationJob;
+use App\Models\AgentStreamRun;
+use App\Models\Conversation;
+use App\Models\User;
+use App\Utilities\ConfigHelper;
+use Illuminate\Support\Facades\Context;
+
+final readonly class StartAgentStreamRunAction
+{
+    public function __construct(
+        private EnforceAiUsageLimit $enforceAiUsageLimit,
+        private DispatchesMemoryExtraction $memoryExtraction,
+    ) {}
+
+    public function handle(StreamChatRequest $request, User $user, string $conversationId, string $channel = 'web'): AgentStreamRun
+    {
+        Context::add('chat.channel', $channel);
+        Context::add('chat.conversation_id', $conversationId);
+
+        $modelName = $request->modelName();
+
+        $this->enforceAiUsageLimit->handle($user, $modelName);
+
+        $payload = new AgentPayload(
+            userId: $user->id,
+            message: $request->userMessage(),
+            images: $request->userAttachments(),
+            modelName: $modelName,
+            conversationId: $conversationId,
+        );
+
+        $this->dispatchSummarizationIfNeeded($conversationId);
+        $this->memoryExtraction->dispatchIfEligible($user->id);
+
+        $run = AgentStreamRun::query()->create([
+            'conversation_id' => $conversationId,
+            'user_id' => $user->id,
+            'agent' => AgentRunner::class,
+            'channel' => $channel,
+            'model' => $modelName->value,
+            'prompt' => $payload->message,
+            'status' => AgentStreamStatus::Queued,
+            'expires_at' => now()->addMinutes(ConfigHelper::int('altani.stream.run_ttl_minutes', 30)),
+        ]);
+
+        dispatch(new StreamAgentRunJob($run->id, $payload))->afterCommit();
+
+        return $run;
+    }
+
+    private function dispatchSummarizationIfNeeded(string $conversationId): void
+    {
+        $conversation = Conversation::query()->find($conversationId);
+
+        if (! $conversation instanceof Conversation) {
+            return;
+        }
+
+        if ($conversation->summarization_dispatched_at?->isAfter(now()->subMinutes(5))) {
+            return;
+        }
+
+        $buffer = ConfigHelper::int('altani.summarization.buffer', 25);
+        $threshold = ConfigHelper::int('altani.summarization.threshold', 20);
+
+        if ($conversation->messages()->count() < ($buffer + $threshold)) {
+            return;
+        }
+
+        $conversation->update(['summarization_dispatched_at' => now()]);
+
+        dispatch(new SummarizeConversationJob($conversation));
+    }
+}

--- a/app/Console/Commands/PruneExpiredStreamRunsCommand.php
+++ b/app/Console/Commands/PruneExpiredStreamRunsCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\AgentStreamChunk;
+use App\Models\AgentStreamRun;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+#[Description('Delete agent stream runs (and their chunks) that have passed their resume TTL.')]
+#[Signature('streams:prune-expired')]
+final class PruneExpiredStreamRunsCommand extends Command
+{
+    public function handle(): int
+    {
+        $pruned = 0;
+
+        AgentStreamRun::query()
+            ->whereNowOrPast('expires_at')
+            ->chunkById(100, function (Collection $expired) use (&$pruned): void {
+                $ids = $expired->modelKeys();
+
+                AgentStreamChunk::query()->whereIn('run_id', $ids)->delete();
+                AgentStreamRun::query()->whereKey($ids)->delete();
+
+                $pruned += count($ids);
+            });
+
+        $this->info($pruned === 0
+            ? 'No expired stream runs to prune.'
+            : sprintf('Pruned %d expired stream run(s).', $pruned));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Contracts/Streaming/ManagesStreamChunks.php
+++ b/app/Contracts/Streaming/ManagesStreamChunks.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Streaming;
+
+use App\Enums\AgentStreamStatus;
+use App\Models\AgentStreamChunk;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+
+interface ManagesStreamChunks
+{
+    public function append(string $runId, int $sequence, StreamEvent $event): void;
+
+    /**
+     * @return iterable<int, AgentStreamChunk>
+     */
+    public function chunksAfter(string $runId, int $sequence): iterable;
+
+    public function latestSequence(string $runId): int;
+
+    public function markRunStatus(string $runId, AgentStreamStatus $status, ?string $error = null): void;
+}

--- a/app/Data/ActiveStreamData.php
+++ b/app/Data/ActiveStreamData.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+
+final class ActiveStreamData extends Data
+{
+    public function __construct(
+        public string $runId,
+        public string $prompt,
+    ) {}
+}

--- a/app/Enums/AgentStreamStatus.php
+++ b/app/Enums/AgentStreamStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AgentStreamStatus: string
+{
+    case Queued = 'queued';
+    case Running = 'running';
+    case Completed = 'completed';
+    case Failed = 'failed';
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::Completed, self::Failed], true);
+    }
+}

--- a/app/Http/Controllers/Api/V2/ChatController.php
+++ b/app/Http/Controllers/Api/V2/ChatController.php
@@ -7,13 +7,17 @@ namespace App\Http\Controllers\Api\V2;
 use App\Actions\BuildAssistantAgentAction;
 use App\Actions\BuildConversationMessagesAction;
 use App\Actions\GetOrCreateConversationAction;
+use App\Actions\ReplayAgentStreamAction;
 use App\Http\Requests\Api\V2\ChatStreamRequest;
+use App\Models\AgentStreamRun;
 use App\Models\Conversation;
 use App\Models\User;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
-use Laravel\Ai\Responses\StreamableAgentResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class ChatController
 {
@@ -21,6 +25,7 @@ final readonly class ChatController
         private BuildConversationMessagesAction $messagesAction,
         private BuildAssistantAgentAction $agentAction,
         private GetOrCreateConversationAction $conversationAction,
+        private ReplayAgentStreamAction $replay,
     ) {}
 
     public function index(#[CurrentUser] User $user): JsonResponse
@@ -49,6 +54,13 @@ final readonly class ChatController
             'id' => $conversation->id,
             'title' => $conversation->title,
             'messages' => $this->messagesAction->handle($conversation),
+            'active_stream' => AgentStreamRun::query()
+                ->active()
+                ->where('conversation_id', $conversation->id)
+                ->latest()
+                ->first()
+                ?->toActiveStreamData()
+                ->toArray(),
         ]);
     }
 
@@ -56,11 +68,34 @@ final readonly class ChatController
         ChatStreamRequest $request,
         #[CurrentUser] User $user,
         string $conversationId
-    ): StreamableAgentResponse {
+    ): StreamedResponse {
         $conversation = $this->conversationAction->handle($conversationId, $user);
         Gate::authorize('view', $conversation);
 
         return $this->agentAction->handle($request, $user, $conversation->id, 'mobile');
+    }
+
+    public function resume(
+        Request $request,
+        #[CurrentUser] User $user,
+        string $conversationId,
+        string $run
+    ): Response {
+        $conversation = $this->conversationAction->handle($conversationId, $user);
+        Gate::authorize('view', $conversation);
+
+        $streamRun = AgentStreamRun::query()
+            ->whereKey($run)
+            ->where('conversation_id', $conversation->id)
+            ->first();
+
+        $from = $request->integer('from', -1);
+
+        if (! $streamRun instanceof AgentStreamRun || ! $this->replay->isResumable($streamRun, $from)) {
+            return response()->noContent();
+        }
+
+        return $this->replay->handle($streamRun->id, $from);
     }
 
     public function destroy(string $conversationId): JsonResponse

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -9,16 +9,20 @@ use App\Actions\Billing\BuildCreditWarning;
 use App\Actions\BuildAssistantAgentAction;
 use App\Actions\BuildConversationMessagesAction;
 use App\Actions\GetOrCreateConversationAction;
+use App\Actions\ReplayAgentStreamAction;
 use App\Http\Requests\StoreChatConversationRequest;
 use App\Http\Requests\StreamChatRequest;
+use App\Models\AgentStreamRun;
 use App\Models\Conversation;
 use App\Models\User;
 use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
-use Laravel\Ai\Responses\StreamableAgentResponse;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class ChatController
 {
@@ -29,6 +33,7 @@ final readonly class ChatController
         private GetOrCreateConversationAction $conversationAction,
         private BuildCreditWarning $buildCreditWarning,
         private BuildConversationApprovalStates $approvalStates,
+        private ReplayAgentStreamAction $replay,
     ) {}
 
     public function index(): Response
@@ -55,15 +60,43 @@ final readonly class ChatController
                 ->currentState($this->user)
                 ?->toArray(),
             'approvals' => fn (): array => $this->approvalStates->handle($conversation),
+            'activeStream' => AgentStreamRun::query()
+                ->active()
+                ->where('conversation_id', $conversation->id)
+                ->latest()
+                ->first()
+                ?->toActiveStreamData()
+                ->toArray(),
         ]);
     }
 
     public function stream(
         StreamChatRequest $request,
         Conversation $conversation
-    ): StreamableAgentResponse {
+    ): StreamedResponse {
         Gate::authorize('view', $conversation);
 
         return $this->agentAction->handle($request, $this->user, $conversation->id);
+    }
+
+    public function resume(
+        Request $request,
+        Conversation $conversation,
+        string $run
+    ): HttpResponse {
+        Gate::authorize('view', $conversation);
+
+        $streamRun = AgentStreamRun::query()
+            ->whereKey($run)
+            ->where('conversation_id', $conversation->id)
+            ->first();
+
+        $from = $request->integer('from', -1);
+
+        if (! $streamRun instanceof AgentStreamRun || ! $this->replay->isResumable($streamRun, $from)) {
+            return response()->noContent();
+        }
+
+        return $this->replay->handle($streamRun->id, $from);
     }
 }

--- a/app/Jobs/StreamAgentRunJob.php
+++ b/app/Jobs/StreamAgentRunJob.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Ai\AgentPayload;
+use App\Ai\Agents\AgentRunner;
+use App\Contracts\Streaming\ManagesStreamChunks;
+use App\Enums\AgentStreamStatus;
+use App\Models\AgentStreamChunk;
+use App\Models\AgentStreamRun;
+use App\Models\History;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Attributes\Timeout;
+use Illuminate\Queue\Attributes\Tries;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Throwable;
+
+#[Timeout(150)]
+#[Tries(1)]
+final class StreamAgentRunJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $runId,
+        public readonly AgentPayload $payload,
+    ) {}
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping($this->runId),
+        ];
+    }
+
+    public function handle(AgentRunner $agentRunner, ManagesStreamChunks $chunks): void
+    {
+        $run = AgentStreamRun::query()->find($this->runId);
+
+        if (! $run instanceof AgentStreamRun) {
+            return;
+        }
+
+        Context::add('chat.channel', $run->channel);
+        Context::add('chat.conversation_id', $run->conversation_id);
+
+        $user = User::query()->find($this->payload->userId);
+
+        if (! $user instanceof User) {
+            $chunks->markRunStatus($this->runId, AgentStreamStatus::Failed, 'User not found.');
+
+            return;
+        }
+
+        $run->update(['status' => AgentStreamStatus::Running]);
+
+        $response = $agentRunner->runWithConversation($this->payload, $user, $run->conversation_id);
+        $run->update(['invocation_id' => $response->invocationId]);
+
+        $coalesce = (bool) config('altani.stream.coalesce_text_deltas', true);
+        $sequence = 0;
+        $failed = false;
+        $buffer = null;
+
+        foreach ($response as $event) {
+            if (! $event instanceof StreamEvent) {
+                continue;
+            }
+
+            if ($coalesce && $event instanceof TextDelta) {
+                if ($buffer !== null && $buffer->messageId !== $event->messageId) {
+                    $chunks->append($this->runId, $sequence++, $buffer);
+                    $buffer = null;
+                }
+
+                if ($buffer === null) {
+                    $buffer = $event;
+                } else {
+                    $buffer->delta .= $event->delta;
+                }
+
+                continue;
+            }
+
+            if ($buffer !== null) {
+                $chunks->append($this->runId, $sequence++, $buffer);
+                $buffer = null;
+            }
+
+            $chunks->append($this->runId, $sequence++, $event);
+
+            if ($event instanceof Error && ! $event->recoverable) {
+                $failed = true;
+                $chunks->markRunStatus($this->runId, AgentStreamStatus::Failed, $event->message);
+            }
+        }
+
+        if ($buffer !== null) {
+            $chunks->append($this->runId, $sequence++, $buffer);
+        }
+
+        if (! $failed) {
+            $this->captureAssistantMessageId($run);
+            $chunks->markRunStatus($this->runId, AgentStreamStatus::Completed);
+        }
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $chunks = resolve(ManagesStreamChunks::class);
+
+        $chunks->append($this->runId, $chunks->latestSequence($this->runId) + 1, new Error(
+            id: (string) Str::uuid7(),
+            type: 'stream_failed',
+            message: 'The stream failed.',
+            recoverable: false,
+            timestamp: now()->getTimestamp(),
+        ));
+
+        $this->persistPartialMessage($exception);
+
+        $chunks->markRunStatus($this->runId, AgentStreamStatus::Failed, $exception->getMessage());
+    }
+
+    private function captureAssistantMessageId(AgentStreamRun $run): void
+    {
+        $message = History::query()
+            ->where('conversation_id', $run->conversation_id)
+            ->where('agent', $run->agent)
+            ->where('role', 'assistant')
+            ->where('created_at', '>=', $run->created_at)
+            ->orderByDesc('id')
+            ->first();
+
+        if ($message instanceof History) {
+            $run->update(['assistant_message_id' => $message->id]);
+        }
+    }
+
+    private function persistPartialMessage(Throwable $exception): void
+    {
+        $run = AgentStreamRun::query()->find($this->runId);
+
+        if (! $run instanceof AgentStreamRun
+            || $run->assistant_message_id !== null
+            || $this->turnMessageExists($run, 'assistant')) {
+            return;
+        }
+
+        $partial = AgentStreamChunk::query()
+            ->where('run_id', $this->runId)
+            ->where('type', 'text_delta')
+            ->orderBy('sequence')
+            ->get(['payload'])
+            ->map(function (AgentStreamChunk $chunk): string {
+                $delta = $chunk->payload['delta'] ?? '';
+
+                return is_string($delta) ? $delta : '';
+            })
+            ->implode('');
+
+        DB::transaction(function () use ($run, $partial, $exception): void {
+            if (! $this->turnMessageExists($run, 'user')) {
+                History::query()->insert($this->messageRow($run, 'user', $run->prompt ?? '', '[]'));
+            }
+
+            if ($partial !== '') {
+                $assistantId = (string) Str::uuid7();
+                History::query()->insert($this->messageRow(
+                    $run,
+                    'assistant',
+                    $partial,
+                    (string) json_encode(['partial' => true, 'error' => Str::limit($exception->getMessage(), 500)]),
+                    $assistantId,
+                ));
+                $run->update(['assistant_message_id' => $assistantId]);
+            }
+        });
+    }
+
+    private function turnMessageExists(AgentStreamRun $run, string $role): bool
+    {
+        return History::query()
+            ->where('conversation_id', $run->conversation_id)
+            ->where('agent', $run->agent)
+            ->where('role', $role)
+            ->where('created_at', '>=', $run->created_at)
+            ->exists();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function messageRow(AgentStreamRun $run, string $role, string $content, string $meta, ?string $id = null): array
+    {
+        $now = now();
+
+        return [
+            'id' => $id ?? (string) Str::uuid7(),
+            'conversation_id' => $run->conversation_id,
+            'user_id' => $run->user_id,
+            'agent' => $run->agent,
+            'role' => $role,
+            'content' => $content,
+            'attachments' => '[]',
+            'tool_calls' => '[]',
+            'tool_results' => '[]',
+            'usage' => '[]',
+            'meta' => $meta,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+}

--- a/app/Jobs/StreamAgentRunJob.php
+++ b/app/Jobs/StreamAgentRunJob.php
@@ -17,6 +17,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -54,9 +55,6 @@ final class StreamAgentRunJob implements ShouldQueue
             return;
         }
 
-        Context::add('chat.channel', $run->channel);
-        Context::add('chat.conversation_id', $run->conversation_id);
-
         $user = User::query()->find($this->payload->userId);
 
         if (! $user instanceof User) {
@@ -65,6 +63,36 @@ final class StreamAgentRunJob implements ShouldQueue
             return;
         }
 
+        Auth::setUser($user);
+        Context::add('chat.channel', $run->channel);
+        Context::add('chat.conversation_id', $run->conversation_id);
+
+        try {
+            $this->stream($run, $user, $agentRunner, $chunks);
+        } finally {
+            Auth::forgetGuards();
+        }
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $chunks = resolve(ManagesStreamChunks::class);
+
+        $chunks->append($this->runId, $chunks->latestSequence($this->runId) + 1, new Error(
+            id: (string) Str::uuid7(),
+            type: 'stream_failed',
+            message: 'The stream failed.',
+            recoverable: false,
+            timestamp: now()->getTimestamp(),
+        ));
+
+        $this->persistPartialMessage($exception);
+
+        $chunks->markRunStatus($this->runId, AgentStreamStatus::Failed, $exception->getMessage());
+    }
+
+    private function stream(AgentStreamRun $run, User $user, AgentRunner $agentRunner, ManagesStreamChunks $chunks): void
+    {
         $run->update(['status' => AgentStreamStatus::Running]);
 
         $response = $agentRunner->runWithConversation($this->payload, $user, $run->conversation_id);
@@ -116,23 +144,6 @@ final class StreamAgentRunJob implements ShouldQueue
             $this->captureAssistantMessageId($run);
             $chunks->markRunStatus($this->runId, AgentStreamStatus::Completed);
         }
-    }
-
-    public function failed(Throwable $exception): void
-    {
-        $chunks = resolve(ManagesStreamChunks::class);
-
-        $chunks->append($this->runId, $chunks->latestSequence($this->runId) + 1, new Error(
-            id: (string) Str::uuid7(),
-            type: 'stream_failed',
-            message: 'The stream failed.',
-            recoverable: false,
-            timestamp: now()->getTimestamp(),
-        ));
-
-        $this->persistPartialMessage($exception);
-
-        $chunks->markRunStatus($this->runId, AgentStreamStatus::Failed, $exception->getMessage());
     }
 
     private function captureAssistantMessageId(AgentStreamRun $run): void

--- a/app/Models/AgentStreamChunk.php
+++ b/app/Models/AgentStreamChunk.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property string $run_id
+ * @property int $sequence
+ * @property string $type
+ * @property array<string, mixed> $payload
+ * @property array<string, mixed>|null $vercel
+ * @property CarbonInterface $created_at
+ * @property-read AgentStreamRun $run
+ */
+#[WithoutTimestamps]
+final class AgentStreamChunk extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'vercel' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<AgentStreamRun, $this>
+     */
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(AgentStreamRun::class, 'run_id');
+    }
+}

--- a/app/Models/AgentStreamRun.php
+++ b/app/Models/AgentStreamRun.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Data\ActiveStreamData;
+use App\Enums\AgentStreamStatus;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $id
+ * @property string $conversation_id
+ * @property int $user_id
+ * @property string $agent
+ * @property string $channel
+ * @property string $model
+ * @property string|null $prompt
+ * @property AgentStreamStatus $status
+ * @property string|null $invocation_id
+ * @property string|null $assistant_message_id
+ * @property string|null $error
+ * @property CarbonInterface $expires_at
+ * @property CarbonInterface|null $finalized_at
+ * @property CarbonInterface $created_at
+ * @property CarbonInterface $updated_at
+ * @property-read User $user
+ * @property-read Conversation $conversation
+ * @property-read Collection<int, AgentStreamChunk> $chunks
+ */
+final class AgentStreamRun extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    protected $guarded = [];
+
+    public function casts(): array
+    {
+        return [
+            'status' => AgentStreamStatus::class,
+            'expires_at' => 'datetime',
+            'finalized_at' => 'datetime',
+        ];
+    }
+
+    public function toActiveStreamData(): ActiveStreamData
+    {
+        return new ActiveStreamData(
+            runId: $this->id,
+            prompt: $this->prompt ?? '',
+        );
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Conversation, $this>
+     */
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    /**
+     * @return HasMany<AgentStreamChunk, $this>
+     */
+    public function chunks(): HasMany
+    {
+        return $this->hasMany(AgentStreamChunk::class, 'run_id');
+    }
+
+    /** @param  Builder<self>  $query */
+    #[Scope]
+    protected function active(Builder $query): void
+    {
+        $query->whereIn('status', [
+            AgentStreamStatus::Queued->value,
+            AgentStreamStatus::Running->value,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Contracts\Memory\PullsConversationHistory;
 use App\Contracts\Services\IndexNowServiceContract;
 use App\Contracts\Services\StripeServiceContract;
 use App\Contracts\Skills\LoadsSkills;
+use App\Contracts\Streaming\ManagesStreamChunks;
 use App\Events\AgentApprovalResolved;
 use App\Listeners\NotifyTelegramOfApprovalOutcome;
 use App\Listeners\TrackAiUsage;
@@ -21,6 +22,7 @@ use App\Services\Memory\NullConversationHistoryPuller;
 use App\Services\Memory\NullMemoryExtractionDispatcher;
 use App\Services\Memory\NullMemoryPromptContext;
 use App\Services\Skills\NullSkillLoader;
+use App\Services\Streaming\DatabaseStreamChunkStore;
 use App\Services\StripeService;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\VerifyEmail;
@@ -46,6 +48,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->bindIf(DispatchesMemoryExtraction::class, NullMemoryExtractionDispatcher::class);
         $this->app->bindIf(PullsConversationHistory::class, NullConversationHistoryPuller::class);
         $this->app->bindIf(LoadsSkills::class, NullSkillLoader::class);
+        $this->app->bindIf(ManagesStreamChunks::class, DatabaseStreamChunkStore::class);
     }
 
     public function boot(): void

--- a/app/Services/Streaming/DatabaseStreamChunkStore.php
+++ b/app/Services/Streaming/DatabaseStreamChunkStore.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Streaming;
+
+use App\Contracts\Streaming\ManagesStreamChunks;
+use App\Enums\AgentStreamStatus;
+use App\Models\AgentStreamChunk;
+use App\Models\AgentStreamRun;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+
+final class DatabaseStreamChunkStore implements ManagesStreamChunks
+{
+    public function append(string $runId, int $sequence, StreamEvent $event): void
+    {
+        AgentStreamChunk::query()->create([
+            'run_id' => $runId,
+            'sequence' => $sequence,
+            'type' => $event->type(),
+            'payload' => json_decode((string) $event, true),
+            'vercel' => $event->toVercelProtocolArray(),
+        ]);
+    }
+
+    public function chunksAfter(string $runId, int $sequence): iterable
+    {
+        return AgentStreamChunk::query()
+            ->where('run_id', $runId)
+            ->where('sequence', '>', $sequence)
+            ->orderBy('sequence')
+            ->get();
+    }
+
+    public function latestSequence(string $runId): int
+    {
+        $max = AgentStreamChunk::query()
+            ->where('run_id', $runId)
+            ->max('sequence');
+
+        return is_numeric($max) ? (int) $max : -1;
+    }
+
+    public function markRunStatus(string $runId, AgentStreamStatus $status, ?string $error = null): void
+    {
+        AgentStreamRun::query()
+            ->whereKey($runId)
+            ->update([
+                'status' => $status->value,
+                'error' => $error,
+                'finalized_at' => $status->isTerminal() ? now() : null,
+                'updated_at' => now(),
+            ]);
+    }
+}

--- a/app/Support/Streaming/VercelChunkStreamer.php
+++ b/app/Support/Streaming/VercelChunkStreamer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Streaming;
+
+final class VercelChunkStreamer
+{
+    private bool $streamStarted = false;
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $toolCalls = [];
+
+    /**
+     * @var array<array-key, mixed>|null
+     */
+    private ?array $deferredEnd = null;
+
+    /**
+     * @param  array<array-key, mixed>|null  $vercel
+     */
+    public function line(?array $vercel): ?string
+    {
+        if ($vercel === null || $vercel === []) {
+            return null;
+        }
+
+        $type = $vercel['type'] ?? null;
+
+        if ($type === 'start') {
+            if ($this->streamStarted) {
+                return null;
+            }
+
+            $this->streamStarted = true;
+        }
+
+        if ($type === 'tool-input-available') {
+            $toolCallId = $vercel['toolCallId'] ?? null;
+
+            if (is_string($toolCallId)) {
+                $this->toolCalls[$toolCallId] = true;
+            }
+        }
+
+        if ($type === 'tool-output-available') {
+            $toolCallId = $vercel['toolCallId'] ?? null;
+
+            if (! is_string($toolCallId) || ! isset($this->toolCalls[$toolCallId])) {
+                return null;
+            }
+        }
+
+        if ($type === 'finish') {
+            $this->deferredEnd = $vercel;
+
+            return null;
+        }
+
+        return $this->encode($vercel);
+    }
+
+    public function trailer(): string
+    {
+        $out = '';
+
+        if ($this->deferredEnd !== null) {
+            $out .= $this->encode($this->deferredEnd);
+        }
+
+        return $out."data: [DONE]\n\n";
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     */
+    private function encode(array $data): string
+    {
+        return 'data: '.json_encode($data)."\n\n";
+    }
+}

--- a/config/altani.php
+++ b/config/altani.php
@@ -38,4 +38,30 @@ return [
         'timeout' => 90,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Streaming Settings
+    |--------------------------------------------------------------------------
+    |
+    | Settings for the durable assistant stream ledger.
+    |
+    | - run_ttl_minutes: How long a stream run (and its persisted chunks) stays
+    |   resumable before it is eligible for pruning. The canonical assistant
+    |   message always remains in the conversation history.
+    | - poll_interval_ms: How often the SSE tail polls the ledger for new chunks.
+    | - stall_seconds: How long the tail waits on a still-queued run (no worker)
+    |   before giving up so the client fails fast instead of hanging.
+    | - max_tail_seconds: Hard wall-clock cap on a single tail connection.
+    | - coalesce_text_deltas: Merge consecutive text deltas into one chunk row to cut
+    |   write amplification (set false to persist every delta verbatim).
+    |
+    */
+    'stream' => [
+        'run_ttl_minutes' => 30,
+        'poll_interval_ms' => 400,
+        'stall_seconds' => 20,
+        'max_tail_seconds' => 150,
+        'coalesce_text_deltas' => true,
+    ],
+
 ];

--- a/database/migrations/2026_06_03_021918_create_agent_stream_chunks_table.php
+++ b/database/migrations/2026_06_03_021918_create_agent_stream_chunks_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_stream_chunks', function (Blueprint $table): void {
+            $table->id();
+            $table->string('run_id', 26);
+            $table->unsignedInteger('sequence');
+            $table->string('type');
+            $table->json('payload');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->unique(['run_id', 'sequence']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_stream_chunks');
+    }
+};

--- a/database/migrations/2026_06_03_021918_create_agent_stream_runs_table.php
+++ b/database/migrations/2026_06_03_021918_create_agent_stream_runs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_stream_runs', function (Blueprint $table): void {
+            $table->string('id', 26)->primary();
+            $table->string('conversation_id', 36);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('agent');
+            $table->string('channel', 25);
+            $table->string('model');
+            $table->string('status', 20)->default('running');
+            $table->string('invocation_id')->nullable();
+            $table->string('assistant_message_id', 36)->nullable();
+            $table->text('error')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamp('finalized_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['conversation_id', 'status']);
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_stream_runs');
+    }
+};

--- a/database/migrations/2026_06_03_024704_add_vercel_to_agent_stream_chunks_table.php
+++ b/database/migrations/2026_06_03_024704_add_vercel_to_agent_stream_chunks_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_stream_chunks', function (Blueprint $table): void {
+            $table->json('vercel')->nullable()->after('payload');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_stream_chunks', function (Blueprint $table): void {
+            $table->dropColumn('vercel');
+        });
+    }
+};

--- a/database/migrations/2026_06_03_031846_add_prompt_to_agent_stream_runs_table.php
+++ b/database/migrations/2026_06_03_031846_add_prompt_to_agent_stream_runs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_stream_runs', function (Blueprint $table): void {
+            $table->text('prompt')->nullable()->after('model');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_stream_runs', function (Blueprint $table): void {
+            $table->dropColumn('prompt');
+        });
+    }
+};

--- a/docs/durable-resumable-ai-streaming.md
+++ b/docs/durable-resumable-ai-streaming.md
@@ -21,7 +21,12 @@
 > **Phase 2 note:** generation now runs in `StreamAgentRunJob` (the sole producer); the POST returns
 > an SSE tail (`ReplayAgentStreamAction`) over the ledger. Each chunk also stores the vendor-computed
 > `toVercelProtocolArray()` (new `vercel` column) so replay re-emits the exact wire form with zero
-> re-derivation. Requires a running queue worker in production.
+> re-derivation. Requires a running queue worker in production. Because the job runs outside the web
+> request, it re-establishes the request-scoped state the agent needs: the chat `Context`
+> (`chat.channel`/`chat.conversation_id`) and the authenticated user (`Auth::setUser`, since the agent's
+> tools and specialists resolve the current user via `Auth::user()`), forgetting guards afterward so the
+> user can't leak to the next job in a shared worker. (`acara-core` memory is unaffected — its context
+> contract takes `userId` explicitly.)
 >
 > **Phase 3 note:** added GET resume endpoints — `chat.stream.resume`
 > (`chat/stream/{conversation}/runs/{run}/resume`) and `api.v2.chat.stream.resume` — that reuse

--- a/docs/durable-resumable-ai-streaming.md
+++ b/docs/durable-resumable-ai-streaming.md
@@ -1,0 +1,345 @@
+# Durable, Resumable AI Streaming
+
+> Status: **Phases 1–5 ✅ shipped.** The durable resumable AI stream is complete end-to-end.
+>
+> **Phase 5 (hardening):** `streams:prune-expired` command (scheduled hourly) deletes runs+chunks past
+> `expires_at`; `StreamAgentRunJob` now coalesces consecutive text deltas into one chunk row
+> (`altani.stream.coalesce_text_deltas`, default true) to cut write amplification, captures
+> `assistant_message_id` on completion, and on hard failure best-effort persists the user prompt + partial
+> answer (`meta.partial=true`, `usage=[]` so no double-charge) with an airtight dedup guard. Reasoning
+> deltas stay raw (text is the dominant volume); the stalled-run tail guard shipped in Phase 2.
+>
+> **Mobile adoption:** the v2 `show` endpoint now also returns `active_stream` ({run_id, prompt} | null)
+> so the iOS app (acara-health-sync) can resume on conversation open via the existing GET resume
+> endpoint. The iOS client adopted resume and refactored its stream parsing onto SwiftAISDK's
+> `readUIMessageStream` (UIMessage snapshots) — see that repo.
+> Scope: backend + frontend rewrite of the AI chat streaming path so long-running generations are
+> **queue-driven, persisted as chunks, and resumable** across disconnects/reloads/worker restarts.
+> Testing is intentionally out of scope for this doc (per request); a minimal manual verification
+> checklist is included at the end.
+>
+> **Phase 2 note:** generation now runs in `StreamAgentRunJob` (the sole producer); the POST returns
+> an SSE tail (`ReplayAgentStreamAction`) over the ledger. Each chunk also stores the vendor-computed
+> `toVercelProtocolArray()` (new `vercel` column) so replay re-emits the exact wire form with zero
+> re-derivation. Requires a running queue worker in production.
+>
+> **Phase 3 note:** added GET resume endpoints — `chat.stream.resume`
+> (`chat/stream/{conversation}/runs/{run}/resume`) and `api.v2.chat.stream.resume` — that reuse
+> `ReplayAgentStreamAction` (`?from={sequence}` cursor). `ReplayAgentStreamAction::isResumable()`
+> drives `204 No Content` (the SDK reads 204 as "no active stream" → client falls back to history)
+> when a run is expired or finished with nothing newer than the cursor. Backend-only; no frontend
+> change yet (Phase 4 wires `useChat({ resume })`).
+>
+> **Phase 4 note:** the web chat now resumes a mid-generation reload. `ChatController@create` exposes
+> an eager `activeStream` prop (`{run_id, prompt}`) for the latest queued/running run; `use-chat-stream.ts`
+> sets `resume: true` + `prepareReconnectToStreamRequest` (→ `chat.stream.resume.url`) and seeds the
+> in-flight user message (the run carries `prompt`, since the SDK only persists the user message when
+> the turn completes). Web-only; the API v2 resume endpoint stays available for the mobile app to adopt.
+> Known minor edges (Phase 5): image attachments aren't re-seeded on reload, and a sub-millisecond
+> race (run completing between the eager `activeStream` read and the deferred `messages` resolution)
+> could momentarily duplicate the in-flight message.
+
+## Context — why this change
+
+Today a chat turn is streamed **synchronously from the web worker**:
+
+- `ChatController@stream` (web) and `Api\V2\ChatController@stream` (mobile) return
+  `Laravel\Ai\Responses\StreamableAgentResponse` directly. The PHP worker holds the live LLM
+  stream for up to `#[Timeout(120)]` (`app/Ai/Agents/AgentRunner.php`).
+- The assistant **and** user messages are persisted **only after the full stream completes
+  server-side**: the SDK's `RememberConversation` middleware
+  (`vendor/laravel/ai/src/Middleware/RememberConversation.php`) registers a `->then()` callback that
+  fires at the end of `StreamableAgentResponse::getIterator()`. The callback writes both rows to
+  `agent_conversation_messages` via `DatabaseConversationStore`.
+
+This is fragile in three concrete ways:
+
+1. **Disconnect = data loss.** If the client drops mid-stream (mobile network, tab close, reload),
+   server-side iteration aborts, `->then()` never runs, and **nothing is persisted** — not even the
+   partial answer.
+2. **No resume.** Reload or reconnect loses the in-flight generation entirely; the frontend
+   (`use-chat-stream.ts`) re-hydrates only finalized history.
+3. **Web worker held hostage.** A 2-minute generation ties up a request worker for its full duration.
+
+**Goal:** generation runs in a background job; every chunk is persisted as produced; an SSE endpoint
+can replay persisted chunks then tail live ones, so any client reattaches seamlessly.
+
+### Verified infrastructure constraints (these shape the design)
+
+| Fact | Value | Source |
+|---|---|---|
+| Broadcast driver | `log` (no-op) | `.env.example` `BROADCAST_CONNECTION=log` |
+| Reverb / Pusher / Ably | **not installed** | absent from `composer.json` |
+| `laravel-echo` / `pusher-js` | **not installed** | absent from `package.json` |
+| `routes/channels.php` | does not exist | — |
+| Queue | `database` (worker runs in dev `composer dev`) | `config/queue.php`, `composer.json` |
+| Cache | `database` | `.env.example` `CACHE_STORE=database` |
+| Frontend AI SDK | `ai@6.0.195`, `@ai-sdk/react@3.0.197` | `node_modules` |
+
+**Implication:** websocket pub/sub is unavailable, so the SDK's `BroadcastAgent` (whose
+`broadcastNow()` is a no-op under `log`) cannot deliver chunks. The live tail must be a **short-interval
+DB poll over an indexed ledger** — durable with **zero new infrastructure**. Reverb is a documented
+*future* swap of only the tail loop (see Phase 5), not a prerequisite.
+
+The frontend SDK already ships the resume primitives we need (currently unused):
+`useChat({ resume: true })`, `DefaultChatTransport.reconnectToStream` (issues a GET, treats `204` as
+"no active stream"), and `prepareReconnectToStreamRequest` (can fully override the GET URL). So the
+client change is small and idiomatic — no hand-rolled `EventSource`.
+
+## Target architecture
+
+```
+POST /chat/stream/{conversation}                 (unchanged route + body)
+  └─ Gate::authorize('view', conversation)
+  └─ StartAgentStreamRunAction
+        ├─ EnforceAiUsageLimit  ── synchronous ── 402 usage_limit_exceeded (unchanged path)
+        ├─ insert agent_stream_runs (status=queued, run_id=ULID, channel, model, prompt snapshot)
+        ├─ dispatchSummarizationIfNeeded + memoryExtraction->dispatchIfEligible  (moved here)
+        └─ dispatch StreamAgentRunJob (afterCommit)
+  └─ return SSE tail = ReplayAgentStreamAction(runId, from=0)   ← web worker freed immediately
+
+StreamAgentRunJob  (queued, the ONLY producer)
+  ├─ Context::add('chat.channel'|'chat.conversation_id')        ← re-established in worker
+  ├─ run = running
+  ├─ AgentRunner->runWithConversation(payload, user, conversationId)   (unchanged)
+  │     ->each(fn StreamEvent $e => StreamChunkStore::append(runId, $e))   ← persist each chunk
+  │     ->then(...)   ← SDK RememberConversation writes canonical assistant message (unchanged)
+  ├─ on StreamStart: copy invocation_id onto run
+  ├─ on completion: copy assistant_message_id onto run; status=completed; AgentStreamed→TrackAiUsage (once)
+  └─ failed(): append terminal stream_failed chunk; status=failed; best-effort partial message
+
+GET …/runs/{run}/resume?from={seq}     (NEW, additive)
+  └─ ReplayAgentStreamAction: replay chunks where sequence>from, then DB-poll tail until terminal
+  └─ 204 when run unknown/expired/already-complete-with-nothing-new  → client falls back to history
+```
+
+Single producer (the job), many pure-reader consumers (the POST tail, reloaded tabs, mobile). Exactly
+**one LLM call per turn**.
+
+## Data model — two new tables
+
+Both use **ULID** PKs where ordering matters (the SDK's `agent_conversations`/`agent_conversation_messages`
+use unsortable UUID `string(36)`, so we do **not** reuse their id scheme for sequencing).
+
+**`agent_stream_runs`** — one row per assistant turn.
+
+| column | type | notes |
+|---|---|---|
+| `id` | `string(26)` PK | run_id, ULID (`HasUlids`) |
+| `conversation_id` | `string(36)` index | → `agent_conversations.id` |
+| `user_id` | FK | |
+| `agent` | string | agent FQCN |
+| `channel` | string | `web` \| `mobile` \| `telegram` |
+| `model` | string | resolved model name |
+| `status` | `string(20)` | `queued` \| `running` \| `completed` \| `failed` |
+| `invocation_id` | string null | SDK invocationId; usage-dedup correlation |
+| `assistant_message_id` | `string(36)` null | the `agent_conversation_messages` row written in `->then()` |
+| `next_sequence` | unsigned int default 0 | atomic per-run counter for chunk sequencing |
+| `error` | text null | |
+| `expires_at` | timestamp | `now()->addMinutes(config('altani.stream.run_ttl_minutes', 30))` |
+| timestamps + `finalized_at` | | |
+
+Index: `(conversation_id, status)` to find the active run for a conversation on reconnect.
+
+**`agent_stream_chunks`** — append-only ledger.
+
+| column | type | notes |
+|---|---|---|
+| `id` | bigint auto PK | cheap insert |
+| `run_id` | `string(26)` index | → runs.id |
+| `sequence` | unsigned int | **`UNIQUE(run_id, sequence)`** — idempotency, no dupes |
+| `type` | string | `StreamEvent::type()` (`text_delta`, `tool_call`, `tool_result`, `stream_start`, `stream_end`, `stream_failed`, …) |
+| `payload` | json | **exactly `$event->toArray()`** (full envelope: id, invocation_id, message_id, delta, timestamp) |
+| `created_at` | timestamp | |
+
+Index: `(run_id, sequence)` for ordered replay-since-N.
+
+**Why store raw `toArray()` (not `toVercelProtocolArray()`):** `toArray()` keeps `invocation_id`,
+`message_id`, and `timestamp`; the Vercel form discards them. We re-derive the exact Vercel wire shape
+at read time, which also keeps storage protocol-version-agnostic across SDK upgrades.
+
+**Canonical transcript is unchanged.** The final message still lives in `agent_conversation_messages`
+(written once by `RememberConversation` inside the job). The ledger is transient: a daily prune deletes
+runs/chunks past `expires_at` (Phase 5). Resuming a long-completed run returns `204`, and the client
+falls back to persisted history via `BuildConversationMessagesAction`.
+
+## Backend components
+
+New, following the repo's Action / Contract (no suffix) / `bindIf` / spatie-data conventions:
+
+- **`app/Contracts/Streaming/StreamChunkStore.php`** (contract, no suffix):
+  `append(string $runId, StreamEvent $event): int`, `chunksAfter(string $runId, int $sequence): iterable`,
+  `latestSequence(string $runId): int`, `markRunStatus(string $runId, string $status): void`.
+  `append()` increments `runs.next_sequence` atomically (`DB::transaction` + `lockForUpdate`) so sequence
+  assignment is dense and never relies on autoincrement gaps.
+- **`app/Services/Streaming/DatabaseStreamChunkStore.php`** — DB implementation. Bound via
+  `AppServiceProvider::bindIf()` so a future `RedisStreamChunkStore` can drop in (consistent with the
+  existing open-core memory pattern; keeps `main` community-safe).
+- **`app/Jobs/StreamAgentRunJob.php`** — `ShouldQueue`, `database` connection, `tries = 1`,
+  `WithoutOverlapping($runId)`, job timeout ≥ 130 (AgentRunner is `#[Timeout(120)]`). Mirrors the
+  *shape* of `vendor/.../Jobs/BroadcastAgent.php` (`->each()`/`->then()`/`failed()`) **without
+  subclassing or patching vendor** — we replicate ~30 lines and swap `broadcastNow()` for
+  `StreamChunkStore::append()`. `failed()` always appends a terminal `stream_failed` chunk (mirrors
+  `BroadcastAgent::failed`) and, if any `text_delta` chunks exist, best-effort persists a partial
+  assistant message so a reload shows the partial answer.
+- **`app/Actions/StartAgentStreamRunAction.php`** — synchronous preflight (`EnforceAiUsageLimit` →
+  preserves the existing `402` JSON), creates the run row, keeps the current `dispatchSummarizationIfNeeded`
+  + `memoryExtraction->dispatchIfEligible` calls (relocated from `BuildAssistantAgentAction`), dispatches
+  the job `afterCommit`, returns `AgentStreamRunData`.
+- **`app/Actions/ReplayAgentStreamAction.php`** — generator: (a) replay chunks `sequence > from`
+  ordered, mapped to Vercel wire shape by type; (b) poll for new chunks every `~400ms` until a terminal
+  chunk OR `run.status in (completed, failed)` OR `expires_at` elapsed; (c) emit deferred finish + `[DONE]`.
+  Includes a **stalled-run guard**: if the run stays `queued` past a few seconds (no worker), emit a
+  terminal error so the client fails gracefully instead of hanging.
+- **`app/Support/Streaming/VercelChunkStreamer.php`** — the single helper that converts stored
+  `toArray()` payloads → Vercel wire objects and reproduces `CanStreamUsingVercelProtocol`'s framing
+  exactly: one `start`, skip orphan tool results, defer the single `finish`, trailing `data: [DONE]`.
+  Used by **both** the POST tail and the GET resume so framing can never drift between them.
+- **Models:** `app/Models/AgentStreamRun.php` (`HasUlids`), `app/Models/AgentStreamChunk.php`.
+- **DTOs:** `app/Data/AgentStreamRunData.php`, `app/Data/StreamChunkData.php` (spatie/laravel-data).
+- **Migrations:** `create_agent_stream_runs_table`, `create_agent_stream_chunks_table`.
+- **Prune command + schedule** (Phase 5): delete runs/chunks past `expires_at`.
+
+Edits:
+
+- **`app/Http/Controllers/ChatController.php`** — `stream()` calls `StartAgentStreamRunAction` then
+  returns the `ReplayAgentStreamAction` tail (from 0) as a Symfony `StreamedResponse` with the exact
+  `CanStreamUsingVercelProtocol` headers (`Cache-Control: no-cache, no-transform`,
+  `Content-Type: text/event-stream`, `x-vercel-ai-ui-message-stream: v1`). Add `resume(Conversation, string $run)`
+  GET method delegating to `ReplayAgentStreamAction(from = ?from)`. Add the running-run lookup to
+  `create()`'s Inertia render as a lazy `activeStream` prop.
+- **`app/Http/Controllers/Api/V2/ChatController.php`** — same two changes. **v2 POST keeps returning the
+  SSE body inline** (the tail), *not* JSON — so the external Health Sync mobile client's POST contract
+  stays byte-compatible. Add the GET resume method.
+- **`routes/web.php`** — `GET chat/stream/{conversation}/runs/{run}/resume` →
+  `Web\ChatController@resume`, name `chat.stream.resume`, inside the existing auth group with the
+  `DisableResponseBuffering` middleware.
+- **`routes/api.php`** — `GET v2/chat/conversations/{conversation}/runs/{run}/resume`, name
+  `api.v2.chat.stream.resume`, under the same `auth:sanctum` + `abilities:chat:converse` group.
+
+## Frontend components
+
+- **`resources/js/hooks/use-chat-stream.ts`** — keep `DefaultChatTransport` + the existing `402`
+  fetch interceptor untouched. Pass `resume: true` to `useChat`. Add `prepareReconnectToStreamRequest`
+  that returns the resume GET URL (built with the Wayfinder `chat.stream.resume` helper) for the active
+  `runId` with the last-seen `sequence` as `?from=`. Learn `activeRunId`/`resumeUrl` from a custom
+  `data-stream-run` data part the POST emits at stream start. Replay is idempotent and the SDK de-dupes
+  parts by id, so an exact cursor is an optimization, not a correctness requirement (default `from=0`
+  is safe).
+- **`resources/js/pages/chat/create-chat.tsx`** — on mount, read the new lazy `activeStream`
+  (`{ runId, lastSequence } | null`) prop; if present, `resume: true` reattaches a mid-generation reload
+  instead of losing it. Persist `activeRunId` to `sessionStorage` keyed by `conversationId` so a hard
+  reload can build the resume request before the first reconnect. Keep the existing
+  `onFinish → router.reload({ only: ['creditWarning'] })`.
+- **`resources/js/types/chat.ts`** — add `activeStream?: { runId: string; lastSequence: number } | null`.
+- **No change to `chat-messages.tsx`** — replayed chunks arrive as ordinary Vercel parts, including
+  mid-stream `data-approval` cards (`extractApprovalPayload` reads `tool_results`).
+
+## HITL approval — already turn-bounded, minimal handling
+
+`AgentApprovalResolved` is a plain in-process event (no `ShouldBroadcast`), and `LogHealthEntry` returns
+a `pending_approval` tool result while the stream **continues**. Under the durable model:
+
+- The `ToolCall` + `ToolResult(pending_approval)` events persist as ordinary chunks → a reconnecting
+  client replays them and re-renders the approval card; a full reload reconstructs it from the finalized
+  message's `tool_results` via `BuildConversationMessagesAction`. Both paths intact, no special code.
+- **Durability win:** because generation lives in the job, the user can approve/reject (existing
+  `ApprovalController → ExecuteApprovalJob`, already queued/DB-backed with retries) and reload **without
+  killing generation**; post-approval text lands as new chunks the tail picks up.
+- **Critical correctness item:** the job **must** `Context::add('chat.channel', $run->channel)` before
+  running the agent — `LogHealthEntry` gates approval on `Context::get('chat.channel')`, and the web
+  request's Context does **not** propagate into the queued worker.
+- The approval state machine (encrypted payload, `AgentApprovalResolved`, Telegram notify) is unchanged.
+
+## Usage accounting — no double-charge by construction
+
+- The LLM runs **exactly once**, in the job. POST tail and GET resume are **read-only** ledger replays
+  that never re-invoke `AgentRunner`.
+- `EnforceAiUsageLimit` runs synchronously at request time (preserving `402`) and is **not** re-run on
+  resume.
+- `TrackAiUsage` fires from `AgentStreamed` once per turn; its `ai_usage_{invocationId}` cache guard
+  de-dupes. Two implementation cautions: (1) the guard's 5-min TTL can be shorter than a long
+  generation — key dedup on the **persisted `runs.invocation_id`** rather than the cache alone; (2)
+  `TrackAiUsage` reads `request->user()` (null in the worker) then falls back to `getUserFromAgent()` —
+  works because the agent is invoked `->continue(as: $user)`, so attribution is correct in the job.
+
+## API v2 compatibility
+
+The external Health Sync app's `POST v2/chat/conversations/{conversation}/stream` stays **byte-compatible**:
+same request body (`ChatStreamRequest`), same inline Vercel-protocol SSE body to completion. Resume is
+**purely additive** (new GET endpoint the app can adopt later). The custom `data-stream-run` part is an
+extra SSE part a Vercel-protocol client ignores if unrecognized. **Net: zero breaking change for v2.**
+
+## Reused primitives (no in-place vendor edits)
+
+`StreamableAgentResponse->each()` (per-event tap), `->then()`/`getIterator()` (still finalizes the
+message via `RememberConversation`), `StreamEvent::toArray()/type()`, the
+`CanStreamUsingVercelProtocol` framing *algorithm* (re-implemented over stored arrays in
+`VercelChunkStreamer`), `DatabaseConversationStore` + `agent_conversation_messages` +
+`BuildConversationMessagesAction`, `AgentRunner->runWithConversation`, `EnforceAiUsageLimit` +
+`TrackAiUsage` + the `invocationId` cache, the full approval stack, `SummarizeConversationJob` + memory
+dispatch, `DisableResponseBuffering`, the `402` fetch interceptor, and the installed-but-unused
+`useChat` resume / `reconnectToStream` / `prepareReconnectToStreamRequest`. `BroadcastAgent` is the
+*template* for the job's shape — replicated, never subclassed/patched.
+
+## Incremental phases (each independently shippable)
+
+1. **Durable ledger behind the current synchronous flow** — add tables, models, `StreamChunkStore` +
+   DB impl, DTOs, and tap the *existing* synchronous controller stream with `->each()` to persist chunks.
+   Controller still returns `StreamableAgentResponse`. No client/queue change. Proves persistence,
+   ordering, `UNIQUE(run_id, sequence)`, partial-answer capture; valuable on its own as crash forensics.
+2. **Move generation to the queue** — `StreamAgentRunJob` + `StartAgentStreamRunAction`; controllers
+   dispatch and return the POST SSE tail (replay from 0). Frees the worker; handles Context
+   re-establishment, `failed()` terminal chunk, in-job usage attribution. Happy-path UX identical; no
+   frontend change yet. Requires a running queue worker.
+3. **Resume endpoint** — `ReplayAgentStreamAction` GET + `VercelChunkStreamer` + routes (web + v2),
+   `204 = null` semantics, replay-then-tail loop. Backend resume usable by any client without touching
+   the frontend.
+4. **Frontend native resume** — `use-chat-stream.ts` (`resume: true` + `prepareReconnectToStreamRequest`
+   + `data-stream-run`) and `create-chat.tsx` (`activeStream` prop). Delivers the user-visible seamless
+   resume.
+5. **Hardening** — scheduled prune of expired runs/chunks; optional `text_delta` coalescing (~50–100ms)
+   to cut write amplification; stalled-run startup guard; and (optional, gated on an infra decision) a
+   Reverb tail swap (only the tail loop changes — ledger, resume token, and HITL logic untouched).
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| No broadcast infra (log driver) | Design around it: DB-poll tail; Reverb documented as a later tail-only swap. |
+| Queue-worker dependency (POST tail stalls with no worker) | Stalled-run guard in the tail loop; document a supervised prod worker (dev `composer dev` already runs `queue:listen`). |
+| Worker loses `chat.channel`/`chat.conversation_id` Context (breaks approval gating) | Re-add Context at the top of `StreamAgentRunJob::handle()` from the run row. **High-priority correctness item.** |
+| Partial answer lost on hard job failure (`->then()` never fires) | `failed()` best-effort persists a partial assistant message from `text_delta` chunks. |
+| Usage dedup TTL (5 min) < long generation | Key dedup on persisted `runs.invocation_id`, not the cache alone; never retry without reusing the same `invocation_id`. |
+| Vercel re-serialization drift vs vendor trait | Single `VercelChunkStreamer` helper; reproduce the framing exactly; re-verify on SDK upgrades. |
+| Sequence assignment race | Atomic `runs.next_sequence` under `lockForUpdate` + `UNIQUE(run_id, sequence)`; single producer per run. |
+| Write amplification (one row per delta) | Optional `text_delta` coalescing (Phase 5) preserving `message_id`/order; TTL prune. |
+| `main` must stay community-safe | All new code is host-app code; no `Acara\AcaraCore` imports, no private composer dep; `StreamChunkStore` contract + `bindIf` default keep it overridable by the private package. |
+
+## Decisions taken (sensible defaults, change on request)
+
+- **Live tail = DB polling now**, Reverb deferred to an optional Phase 5 swap (matches verified infra +
+  the "durability, no new infra" framing).
+- **Run/chunk TTL = 30 min**, daily prune; resume of older runs falls back to message history.
+- **v2 POST stays SSE-inline** (byte-compatible); GET resume is additive/opt-in for mobile.
+- **No `text_delta` coalescing in v1** (exact fidelity); revisit as Phase 5 hardening if write volume bites.
+- **Poll interval = 400 ms** default, configurable.
+
+Open items genuinely needing your input before/at Phase 2: confirm a **supervised production queue
+worker** is available (hard prerequisite for durability), and whether mobile should adopt resume now or
+stay POST-only.
+
+## Verification (manual — no automated tests per request)
+
+- **Phase 1:** send a message; confirm `agent_stream_chunks` fills in order with dense `sequence` and a
+  terminal `stream_end`; kill the connection mid-stream and confirm chunks + a partial message survive.
+- **Phase 2:** confirm `composer dev`'s queue worker runs the job; the POST still streams to completion;
+  exactly one `ai_usages` row per turn; an over-limit user still gets `402`.
+- **Phase 3:** `curl` the GET resume with `?from=0` mid-run → replays then tails to `[DONE]`; with
+  `?from=<last>` after completion → `204`.
+- **Phase 4:** in the browser, start a long generation, reload mid-stream → it reattaches and finishes;
+  open a second tab on the same conversation → both tail correctly; trigger a health-log approval card,
+  reload, confirm the card re-renders and approval still executes.
+- The one check worth automating despite the no-tests scope: a byte-compatibility assertion that
+  `VercelChunkStreamer` output for a recorded chunk sequence matches the vendor synchronous Vercel form
+  (prevents `@ai-sdk/react` desync). Optional, flagged for when you want it.

--- a/resources/js/hooks/use-chat-stream.ts
+++ b/resources/js/hooks/use-chat-stream.ts
@@ -1,6 +1,6 @@
-import { stream } from '@/routes/chat';
+import chat from '@/routes/chat';
 import type { PaywallCapTrigger, SubscriptionTier } from '@/types';
-import type { ChatStatus } from '@/types/chat';
+import type { ActiveStream, ChatStatus } from '@/types/chat';
 import { useChat, type UIMessage } from '@ai-sdk/react';
 import type { ChatOnFinishCallback, FileUIPart } from 'ai';
 import { DefaultChatTransport } from 'ai';
@@ -10,6 +10,7 @@ interface UseChatStreamOptions {
     conversationId: string;
     initialMessages: UIMessage[];
     onFinish?: ChatOnFinishCallback<UIMessage>;
+    activeStream?: ActiveStream | null;
 }
 
 interface UseChatStreamReturn {
@@ -46,15 +47,26 @@ export function useChatStream({
     conversationId,
     initialMessages,
     onFinish,
+    activeStream,
 }: UseChatStreamOptions): UseChatStreamReturn {
     const [networkError, setNetworkError] = useState<Error | undefined>();
     const [usageLimitTrigger, setUsageLimitTrigger] =
         useState<PaywallCapTrigger | null>(null);
 
+    const activeRunId = activeStream?.run_id ?? null;
+
     const transport = useMemo(
         () =>
             new DefaultChatTransport({
-                api: stream.url(conversationId),
+                api: chat.stream.url(conversationId),
+                prepareReconnectToStreamRequest: activeRunId
+                    ? () => ({
+                          api: chat.stream.resume.url({
+                              conversation: conversationId,
+                              run: activeRunId,
+                          }),
+                      })
+                    : undefined,
                 fetch: async (input, init) => {
                     const response = await fetch(input, init);
 
@@ -79,8 +91,22 @@ export function useChatStream({
                     return response;
                 },
             }),
-        [conversationId],
+        [conversationId, activeRunId],
     );
+
+    const seededMessages = useMemo<UIMessage[]>(() => {
+        if (!activeStream) {
+            return initialMessages;
+        }
+
+        const inflightUserMessage = {
+            id: `inflight-${activeStream.run_id}`,
+            role: 'user',
+            parts: [{ type: 'text', text: activeStream.prompt }],
+        } as UIMessage;
+
+        return [...initialMessages, inflightUserMessage];
+    }, [initialMessages, activeStream]);
 
     const {
         messages,
@@ -88,8 +114,9 @@ export function useChatStream({
         status,
         error,
     } = useChat({
-        messages: initialMessages,
+        messages: seededMessages,
         transport,
+        resume: Boolean(activeRunId),
         onFinish,
     });
 

--- a/resources/js/pages/chat/create-chat.tsx
+++ b/resources/js/pages/chat/create-chat.tsx
@@ -30,6 +30,7 @@ export default function CreateChat() {
         messages: messageHistories,
         initialPrompt,
         creditWarning: sharedCreditWarning,
+        activeStream,
     } = page.props;
 
     const [conversationId, setConversationId] = useState<string>(
@@ -70,6 +71,7 @@ export default function CreateChat() {
         conversationId,
         initialMessages,
         onFinish: handleStreamFinish,
+        activeStream,
     });
 
     useEffect(() => {

--- a/resources/js/types/chat.ts
+++ b/resources/js/types/chat.ts
@@ -4,10 +4,16 @@ export type { UIMessage } from '@ai-sdk/react';
 
 export type ChatStatus = 'ready' | 'submitted' | 'streaming' | 'error';
 
+export interface ActiveStream {
+    run_id: string;
+    prompt: string;
+}
+
 export interface ChatPageProps {
     conversationId: string;
     initialPrompt?: string | null;
     messages: UIMessage[];
+    activeStream?: ActiveStream | null;
     [key: string]: unknown;
 }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,10 @@ Route::prefix('v2/chat')
             ->middleware('throttle:30,1')
             ->name('api.v2.chat.stream');
 
+        Route::get('conversations/{conversation}/runs/{run}/resume', [ApiV2\ChatController::class, 'resume'])
+            ->middleware('throttle:60,1')
+            ->name('api.v2.chat.stream.resume');
+
         Route::delete('conversations/{conversation}', [ApiV2\ChatController::class, 'destroy'])
             ->middleware('throttle:30,1')
             ->name('api.v2.chat.destroy');

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 use App\Console\Commands\AggregateHealthDailyCommand;
 use App\Console\Commands\ExpireStaleAgentApprovalsCommand;
 use App\Console\Commands\ProcessGlucoseNotificationsCommand;
+use App\Console\Commands\PruneExpiredStreamRunsCommand;
 use App\Console\Commands\PurgeDeletedUserDataCommand;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('model:prune')->daily();
 
 Schedule::command(ExpireStaleAgentApprovalsCommand::class)->hourly();
+
+Schedule::command(PruneExpiredStreamRunsCommand::class)->hourly();
 
 Schedule::command(ProcessGlucoseNotificationsCommand::class)->dailyAt('08:00');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,9 @@ Route::middleware(['auth', 'verified', EnsureDisclaimerAccepted::class])->group(
     Route::post('chat/stream/{conversation}', [Web\ChatController::class, 'stream'])
         ->middleware([DisableResponseBuffering::class, 'throttle:30,1'])
         ->name('chat.stream');
+    Route::get('chat/stream/{conversation}/runs/{run}/resume', [Web\ChatController::class, 'resume'])
+        ->middleware([DisableResponseBuffering::class, 'throttle:60,1'])
+        ->name('chat.stream.resume');
 
     Route::get('conversations/{conversation}/approvals/{approval}', [Web\ApprovalController::class, 'show'])
         ->name('approvals.show');

--- a/tests/Feature/Controllers/ChatControllerTest.php
+++ b/tests/Feature/Controllers/ChatControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\Conversation;
 use App\Models\History;
 use App\Models\User;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
 
 use function Pest\Laravel\actingAs;
 
@@ -98,6 +99,8 @@ it('validates stream endpoint', function (): void {
 });
 
 it('accepts valid stream request', function (): void {
+    Queue::fake();
+
     $user = User::factory()->create();
     $conversation = Conversation::factory()->create(['user_id' => $user->id]);
 

--- a/tests/Feature/Controllers/ChatStreamPreflightTest.php
+++ b/tests/Feature/Controllers/ChatStreamPreflightTest.php
@@ -7,10 +7,13 @@ use App\Models\AiUsage;
 use App\Models\Conversation;
 use App\Models\User;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
 
 covers(ChatController::class);
 
 beforeEach(function (): void {
+    Queue::fake();
+
     Config::set('plate.enable_premium_upgrades', true);
     Config::set('plate.ai_usage_preflight', [
         'token_budget' => ['input' => 2_000, 'output' => 1_000],

--- a/tests/Feature/SelfHost/PremiumUpgradesDisabledTest.php
+++ b/tests/Feature/SelfHost/PremiumUpgradesDisabledTest.php
@@ -102,6 +102,8 @@ it('lets the StartMealPlanGeneration tool run for free users when the flag is of
 });
 
 it('returns no 402 from chat stream preflight when the flag is off', function (): void {
+    Queue::fake();
+
     $user = User::factory()->create();
     $conversation = Conversation::factory()->create(['user_id' => $user->id]);
 

--- a/tests/Unit/Actions/BuildAssistantAgentActionTest.php
+++ b/tests/Unit/Actions/BuildAssistantAgentActionTest.php
@@ -6,7 +6,8 @@ use App\Actions\BuildAssistantAgentAction;
 use App\Enums\ModelName;
 use App\Http\Requests\StreamChatRequest;
 use App\Models\User;
-use Laravel\Ai\Responses\StreamableAgentResponse;
+use Illuminate\Support\Facades\Queue;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 covers(BuildAssistantAgentAction::class);
 
@@ -39,12 +40,14 @@ function makeStreamRequest(
     return $request;
 }
 
-it('returns a StreamableAgentResponse', function (): void {
+it('returns a streamed response', function (): void {
+    Queue::fake();
+
     $user = User::factory()->create();
     $request = makeStreamRequest();
 
     $conversationId = (string) fake()->uuid();
     $response = $this->action->handle($request, $user, $conversationId);
 
-    expect($response)->toBeInstanceOf(StreamableAgentResponse::class);
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
 });


### PR DESCRIPTION
## What

Reworks AI chat streaming so long-running generations are **queue-driven, persisted as chunks, and resumable** across disconnects, reloads, and worker restarts. Previously generation streamed synchronously from the web worker, so a mid-stream disconnect lost everything (nothing persisted until the full response completed).

## How

- **Durable ledger** — `agent_stream_runs` + `agent_stream_chunks` (each chunk stores the raw `toArray()` payload **and** the vendor `toVercelProtocolArray()` form for zero-drift replay). `ManagesStreamChunks` contract + `DatabaseStreamChunkStore`.
- **Queued producer** — `StreamAgentRunJob` runs the agent off the web worker, persisting each chunk; it's the *only* producer. The POST tail and a new **GET resume endpoint** (`chat.stream.resume`, `api.v2.chat.stream.resume`) are read-only ledger consumers via `ReplayAgentStreamAction` (replay-then-tail). `204` = "no active stream" → client falls back to history.
- **Frontend** — `useChat({ resume })` reattaches a mid-generation reload via an eager `activeStream` prop (seeding the in-flight user prompt). API v2 `show` exposes `active_stream` so the iOS app can adopt resume.
- **Hardening** — hourly `streams:prune-expired`; text-delta coalescing (`altani.stream.coalesce_text_deltas`) to cut write amplification; `assistant_message_id` capture; best-effort partial-message persistence on job failure (`usage=[]`, dedup-guarded → no double-charge).

Design + rationale: `docs/durable-resumable-ai-streaming.md`.

## Verification

- Full suite green (2544 passed); Pint + PHPStan clean.
- End-to-end verified with a faked agent: producer → ledger → tail, resume `isResumable`/204, coalescing (deltas collapse to one chunk), partial-on-failure (+ dedup).

## Notes

- **Community-safe**: no `acara-app/acara-core` dependency, no private-namespace imports; `ManagesStreamChunks` uses `bindIf` so a private package can override the store later.
- Requires a running queue worker in production (dev `composer dev` already runs `queue:listen`).
- An unrelated repo-wide command-attribute codemod is **not** part of this PR (left out deliberately).