### PR TITLE
ci: add Redis service so chat-stream tests can connect

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,17 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

CI on `main` has been red on every run. The `composer test` → `test:unit` gate fails with **9 tests** erroring (`RedisException` → HTTP 500 instead of 202):

- `Tests\Feature\Controllers\ChatStreamPreflightTest` (×2)
- `Tests\Feature\Controllers\ChatControllerTest`
- `Tests\Feature\StartChatStreamTitleDispatchTest` (×2)
- `Tests\Feature\StartChatStreamSummarizationDispatchTest` (×3)
- `Tests\Feature\SelfHost\PremiumUpgradesDisabledTest`

## Root cause

These tests route through `StartChatStream::handle()`, which calls `StreamEventStore::clear()` → `Redis::connection()->del()` **during the HTTP request** (durable stream-replay storage uses a raw Redis connection by design). `phpunit.xml` already neutralizes cache/queue/broadcast/session (array/sync/null), but the raw Redis connection still needs a live server.

The workflow had **no Redis service**, so the connection was refused → `RedisException` → 500. The suite passes locally (Docker `redis:alpine`) and in prod (managed Valkey) — only CI lacked a server.

Reproduced locally by pointing `REDIS_HOST`/`REDIS_PORT` at a dead port: identical `500 is identical to 202` failures.

## Fix

Add a Redis service container reachable at `127.0.0.1:6379`, matching `.env.example` (`REDIS_HOST=127.0.0.1`, no password) and the local/prod setup. phpredis is already loaded in CI (`RedisException` is its class), so no extension change is needed.