### PR TITLE
feat(snap-to-track): mobile JSON API for analyze and meal logging

### DIFF
--- a/app/Actions/LogReviewedMealAction.php
+++ b/app/Actions/LogReviewedMealAction.php
@@ -19,9 +19,13 @@ final readonly class LogReviewedMealAction
         private DispatchAggregateUserUtcDatesAction $dispatchAggregateUserUtcDates,
     ) {}
 
-    public function handle(AnalysisDraft $draft, HealthLogData $data, User $user): string
-    {
-        $sample = DB::transaction(function () use ($draft, $data, $user): HealthSyncSample|string {
+    public function handle(
+        AnalysisDraft $draft,
+        HealthLogData $data,
+        User $user,
+        HealthEntrySource $source = HealthEntrySource::Web,
+    ): string {
+        $sample = DB::transaction(function () use ($draft, $data, $user, $source): HealthSyncSample|string {
             $consumed = AnalysisDraft::query()
                 ->whereKey($draft->id)
                 ->where('user_id', $user->id)
@@ -32,7 +36,7 @@ final readonly class LogReviewedMealAction
                 return $this->previouslyRecordedGroupId($draft, $user);
             }
 
-            $recorded = $this->recordHealthSample->handle($data, $user, HealthEntrySource::Web);
+            $recorded = $this->recordHealthSample->handle($data, $user, $source);
 
             AnalysisDraft::query()
                 ->whereKey($draft->id)

--- a/app/Enums/AnalysisDraftSource.php
+++ b/app/Enums/AnalysisDraftSource.php
@@ -8,4 +8,5 @@ enum AnalysisDraftSource: string
 {
     case PublicSnapToTrack = 'public_snap_to_track';
     case AuthenticatedSnapToTrack = 'authenticated_snap_to_track';
+    case MobileSnapToTrack = 'mobile_snap_to_track';
 }

--- a/app/Enums/HealthEntrySource.php
+++ b/app/Enums/HealthEntrySource.php
@@ -10,4 +10,5 @@ enum HealthEntrySource: string
     case Chat = 'chat';
     case Telegram = 'telegram';
     case MobileSync = 'mobile_sync';
+    case Mobile = 'mobile';
 }

--- a/app/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoController.php
+++ b/app/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V2\SnapToTrack;
+
+use App\Actions\AnalyzeFoodPhotoAction;
+use App\Actions\Billing\EnforceAiUsageLimit;
+use App\Actions\CreateAnalysisDraftAction;
+use App\Enums\AnalysisDraftSource;
+use App\Enums\ModelName;
+use App\Http\Requests\Api\V2\SnapToTrack\AnalyzeSnapToTrackPhotoRequest;
+use App\Models\AnalysisDraft;
+use App\Models\User;
+use App\Utilities\LanguageUtil;
+use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Http\JsonResponse;
+use Throwable;
+
+final readonly class AnalyzeSnapToTrackPhotoController
+{
+    public function __construct(
+        private AnalyzeFoodPhotoAction $analyzeFoodPhoto,
+        private CreateAnalysisDraftAction $createAnalysisDraft,
+        private EnforceAiUsageLimit $enforceAiUsageLimit,
+    ) {}
+
+    public function __invoke(AnalyzeSnapToTrackPhotoRequest $request, #[CurrentUser] User $user): JsonResponse
+    {
+        $this->enforceAiUsageLimit->handle(
+            $user,
+            ModelName::tryFrom(config()->string('plate.food_photo_analyzer.model')),
+        );
+
+        $image = $request->image();
+
+        ['label' => $language, 'code' => $languageCode] = LanguageUtil::resolve(
+            $this->requestedLocale($request) ?? $user->locale,
+        );
+
+        try {
+            $analysis = $this->analyzeFoodPhoto->handle(
+                $image->base64(),
+                $image->mimeType,
+                $language,
+                $languageCode,
+            );
+        } catch (Throwable $throwable) {
+            report($throwable);
+
+            return response()->json(['error' => 'analysis_failed'], 500);
+        }
+
+        $token = $this->createAnalysisDraft->handle(
+            $analysis,
+            AnalysisDraftSource::MobileSnapToTrack,
+            $user->id,
+        );
+
+        $draft = AnalysisDraft::query()
+            ->where('token_hash', AnalysisDraft::hashToken($token))
+            ->first();
+
+        return response()->json([
+            'draft_token' => $token,
+            'expires_at' => $draft?->expires_at->toIso8601String(),
+            'analysis' => $analysis->toArray(),
+        ]);
+    }
+
+    private function requestedLocale(AnalyzeSnapToTrackPhotoRequest $request): ?string
+    {
+        foreach ($request->getLanguages() as $language) {
+            $code = mb_strtolower(explode('_', str_replace('-', '_', $language))[0]);
+
+            if (LanguageUtil::has($code)) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/Api/V2/SnapToTrack/StoreSnapToTrackMealController.php
+++ b/app/Http/Controllers/Api/V2/SnapToTrack/StoreSnapToTrackMealController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V2\SnapToTrack;
+
+use App\Actions\LogReviewedMealAction;
+use App\Data\ReviewedMealData;
+use App\Enums\HealthEntrySource;
+use App\Http\Requests\Api\V2\SnapToTrack\StoreSnapToTrackMealRequest;
+use App\Models\AnalysisDraft;
+use App\Models\User;
+use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+
+final readonly class StoreSnapToTrackMealController
+{
+    public function __construct(private LogReviewedMealAction $logReviewedMeal) {}
+
+    public function __invoke(
+        StoreSnapToTrackMealRequest $request,
+        #[CurrentUser] User $user,
+        string $draft,
+    ): JsonResponse {
+        $draftModel = AnalysisDraft::query()
+            ->where('token_hash', AnalysisDraft::hashToken($draft))
+            ->where('user_id', $user->id)
+            ->where('schema_version', AnalysisDraft::SCHEMA_VERSION)
+            ->first();
+
+        if (! $draftModel instanceof AnalysisDraft) {
+            return $this->unavailable('invalid', 404);
+        }
+
+        $replay = $draftModel->isConsumed();
+        $meal = ReviewedMealData::fromValidated($request->validated());
+
+        try {
+            $groupId = $this->logReviewedMeal->handle(
+                $draftModel,
+                $meal->toHealthLogData($draftModel),
+                $user,
+                HealthEntrySource::Mobile,
+            );
+        } catch (InvalidArgumentException) {
+            return $this->unavailable('consumed', 409);
+        }
+
+        return response()->json([
+            'group_id' => $groupId,
+            'measured_at' => $meal->measuredAt->toIso8601String(),
+            'totals' => [
+                'calories' => $meal->totalOf('calories'),
+                'protein' => $meal->totalOf('protein'),
+                'carbs' => $meal->totalOf('carbs'),
+                'fat' => $meal->totalOf('fat'),
+            ],
+        ], $replay ? 200 : 201);
+    }
+
+    private function unavailable(string $reason, int $status): JsonResponse
+    {
+        return response()->json([
+            'error' => 'draft_unavailable',
+            'reason' => $reason,
+        ], $status);
+    }
+}

--- a/app/Http/Requests/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoRequest.php
+++ b/app/Http/Requests/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V2\SnapToTrack;
+
+use App\Rules\ValidBase64Image;
+use App\Utilities\Base64Image;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use RuntimeException;
+
+final class AnalyzeSnapToTrackPhotoRequest extends FormRequest
+{
+    private const int MAX_KILOBYTES = 10240;
+
+    private ?Base64Image $decoded = null;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'photo' => ['required', 'string', new ValidBase64Image(self::MAX_KILOBYTES)],
+        ];
+    }
+
+    public function image(): Base64Image
+    {
+        if ($this->decoded instanceof Base64Image) {
+            return $this->decoded;
+        }
+
+        $decoded = Base64Image::decode($this->string('photo')->toString());
+
+        if (! $decoded instanceof Base64Image) {
+            throw new RuntimeException('Photo failed to decode after validation.');
+        }
+
+        return $this->decoded = $decoded;
+    }
+}

--- a/app/Http/Requests/Api/V2/SnapToTrack/StoreSnapToTrackMealRequest.php
+++ b/app/Http/Requests/Api/V2/SnapToTrack/StoreSnapToTrackMealRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Requests\SnapToTrack;
+namespace App\Http\Requests\Api\V2\SnapToTrack;
 
 use App\Http\Requests\Concerns\ValidatesReviewedMeal;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Concerns/ValidatesReviewedMeal.php
+++ b/app/Http/Requests/Concerns/ValidatesReviewedMeal.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Concerns;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\Validator;
+
+trait ValidatesReviewedMeal
+{
+    private const array TOTAL_CAPS = [
+        'calories' => 5000,
+        'carbs' => 1000,
+        'protein' => 500,
+        'fat' => 500,
+    ];
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'items' => ['required', 'array', 'min:1', 'max:30'],
+            'items.*.name' => ['required', 'string', 'max:100'],
+            'items.*.portion' => ['nullable', 'string', 'max:100'],
+            'items.*.calories' => ['nullable', 'numeric', 'min:0', 'max:5000'],
+            'items.*.protein' => ['nullable', 'numeric', 'min:0', 'max:500'],
+            'items.*.carbs' => ['nullable', 'numeric', 'min:0', 'max:1000'],
+            'items.*.fat' => ['nullable', 'numeric', 'min:0', 'max:500'],
+            'items.*.provenance' => ['nullable', 'string', 'in:model,reference,user'],
+            'measured_at' => ['required', 'date'],
+            'notes' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $items = $this->input('items');
+
+            if (! is_array($items)) {
+                return;
+            }
+
+            foreach (self::TOTAL_CAPS as $field => $cap) {
+                $total = 0.0;
+
+                foreach ($items as $item) {
+                    $value = is_array($item) ? ($item[$field] ?? null) : null;
+                    $total += is_numeric($value) ? (float) $value : 0.0;
+                }
+
+                if ($total > $cap) {
+                    $validator->errors()->add(
+                        'items',
+                        __('The combined :field of all items may not exceed :cap.', ['field' => $field, 'cap' => $cap]),
+                    );
+                }
+            }
+        });
+    }
+}

--- a/app/Rules/ValidBase64Image.php
+++ b/app/Rules/ValidBase64Image.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Utilities\Base64Image;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+final readonly class ValidBase64Image implements ValidationRule
+{
+    public function __construct(private int $maxKilobytes) {}
+
+    /**
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            $fail('The :attribute field must be an image.');
+
+            return;
+        }
+
+        $image = Base64Image::decode($value);
+
+        if (! $image instanceof Base64Image) {
+            $fail('The :attribute field must be an image.');
+
+            return;
+        }
+
+        if ($image->byteLength() > $this->maxKilobytes * 1024) {
+            $fail('The :attribute field must not be greater than :max kilobytes.')
+                ->translate(['max' => $this->maxKilobytes]);
+        }
+    }
+}

--- a/app/Utilities/Base64Image.php
+++ b/app/Utilities/Base64Image.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+final readonly class Base64Image
+{
+    /**
+     * @var list<string>
+     */
+    public const array ALLOWED_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+    ];
+
+    private function __construct(
+        public string $bytes,
+        public string $mimeType,
+    ) {}
+
+    public static function decode(string $value): ?self
+    {
+        $payload = self::stripDataUrlPrefix(mb_trim($value));
+
+        if ($payload === '') {
+            return null;
+        }
+
+        $bytes = base64_decode($payload, true);
+
+        if ($bytes === false || $bytes === '') {
+            return null;
+        }
+
+        $info = @getimagesizefromstring($bytes);
+
+        if ($info === false) {
+            return null;
+        }
+
+        $mimeType = $info['mime'];
+
+        if (! in_array($mimeType, self::ALLOWED_MIME_TYPES, true)) {
+            return null;
+        }
+
+        return new self($bytes, $mimeType);
+    }
+
+    public function base64(): string
+    {
+        return base64_encode($this->bytes);
+    }
+
+    public function byteLength(): int
+    {
+        return mb_strlen($this->bytes, '8bit');
+    }
+
+    private static function stripDataUrlPrefix(string $value): string
+    {
+        if (! str_starts_with($value, 'data:')) {
+            return $value;
+        }
+
+        $separator = mb_strpos($value, ',');
+
+        if ($separator === false) {
+            return '';
+        }
+
+        return mb_substr($value, $separator + 1);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -107,3 +107,15 @@ Route::prefix('v2/account')
             ->middleware('throttle:30,1')
             ->name('api.v2.account.consent');
     });
+
+Route::prefix('v2/snap-to-track')
+    ->middleware('auth:sanctum')
+    ->group(function (): void {
+        Route::post('analyze', ApiV2\SnapToTrack\AnalyzeSnapToTrackPhotoController::class)
+            ->middleware('throttle:snap-to-track-analyze')
+            ->name('api.v2.snap-to-track.analyze');
+
+        Route::post('drafts/{draft}/meal', ApiV2\SnapToTrack\StoreSnapToTrackMealController::class)
+            ->middleware('throttle:60,1')
+            ->name('api.v2.snap-to-track.meal');
+    });

--- a/tests/Feature/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoControllerTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Agents\FoodPhotoAnalyzerAgent;
+use App\Contracts\Billing\ResolvesUserTier;
+use App\Data\Billing\TierEntitlement;
+use App\Enums\SubscriptionTier;
+use App\Http\Controllers\Api\V2\SnapToTrack\AnalyzeSnapToTrackPhotoController;
+use App\Models\AiUsage;
+use App\Models\AnalysisDraft;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\RateLimiter;
+use Laravel\Sanctum\Sanctum;
+
+covers(AnalyzeSnapToTrackPhotoController::class);
+
+function apiSnapPhotoBase64(): string
+{
+    $file = UploadedFile::fake()->image('meal.jpg', 64, 64);
+
+    return base64_encode((string) file_get_contents((string) $file->getRealPath()));
+}
+
+function apiSnapPhotoDataUrl(): string
+{
+    return 'data:image/jpeg;base64,'.apiSnapPhotoBase64();
+}
+
+function fakeApiSnapAnalysis(): void
+{
+    FoodPhotoAnalyzerAgent::fake([[
+        'items' => [
+            ['name' => 'Avocado toast', 'calories' => 320, 'protein' => 9, 'carbs' => 30, 'fat' => 19, 'portion' => '1 slice'],
+        ],
+        'total_calories' => 320,
+        'total_protein' => 9,
+        'total_carbs' => 30,
+        'total_fat' => 19,
+        'confidence' => 74,
+    ]]);
+}
+
+function stubApiSnapTier(SubscriptionTier $tier): void
+{
+    app()->instance(ResolvesUserTier::class, new class($tier) implements ResolvesUserTier
+    {
+        public function __construct(private readonly SubscriptionTier $tier) {}
+
+        public function resolve(User $user): TierEntitlement
+        {
+            return new TierEntitlement(tier: $this->tier);
+        }
+    });
+}
+
+function zeroApiSnapCreditBudget(): void
+{
+    config()->set('plate.tier_limits.free', [
+        'rolling' => ['limit' => 0.0, 'period_hours' => 24],
+        'weekly' => ['limit' => 0.0, 'period_days' => 7],
+    ]);
+}
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->token = $this->user->createToken('mobile:test', ['chat:converse'])->plainTextToken;
+
+    RateLimiter::clear('snap-to-track-analyze:'.$this->user->id);
+});
+
+it('requires authentication', function (): void {
+    $this->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertUnauthorized();
+});
+
+it('analyzes a data url photo into a claimed mobile draft', function (): void {
+    fakeApiSnapAnalysis();
+
+    $response = $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['draft_token', 'expires_at', 'analysis' => ['items', 'total_calories', 'confidence']])
+        ->assertJsonPath('analysis.total_calories', 320)
+        ->assertJsonPath('analysis.confidence', 74)
+        ->assertJsonPath('analysis.items.0.name', 'Avocado toast');
+
+    $draft = AnalysisDraft::query()->sole();
+
+    expect($draft->user_id)->toBe($this->user->id)
+        ->and($draft->claimed_at)->not->toBeNull()
+        ->and($draft->source->value)->toBe('mobile_snap_to_track')
+        ->and($draft->payload['total_calories'])->toEqual(320)
+        ->and($response->json('draft_token'))->toBeString()
+        ->and($draft->token_hash)->toBe(AnalysisDraft::hashToken((string) $response->json('draft_token')))
+        ->and($response->json('expires_at'))->not->toBeEmpty();
+});
+
+it('accepts a bare base64 payload without a data url prefix', function (): void {
+    fakeApiSnapAnalysis();
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoBase64()])
+        ->assertOk();
+
+    expect(AnalysisDraft::query()->count())->toBe(1);
+});
+
+it('validates the photo payload', function (mixed $photo): void {
+    $payload = $photo === null ? [] : ['photo' => $photo];
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), $payload)
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['photo']);
+
+    expect(AnalysisDraft::query()->count())->toBe(0);
+})->with([
+    'missing' => [null],
+    'not base64' => ['@@@not-base64@@@'],
+    'base64 of non-image bytes' => [fn (): string => base64_encode('this is definitely not an image')],
+    'data url with no payload' => ['data:image/jpeg;base64,'],
+]);
+
+it('reports the failure and stores nothing when the analyzer throws', function (): void {
+    FoodPhotoAnalyzerAgent::fake(function (): void {
+        throw new Exception('AI analysis failed');
+    });
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertStatus(500)
+        ->assertJsonPath('error', 'analysis_failed');
+
+    expect(AnalysisDraft::query()->count())->toBe(0);
+});
+
+it('returns 402 with the usage payload and spends nothing when the credit budget is exhausted', function (): void {
+    stubApiSnapTier(SubscriptionTier::Free);
+    zeroApiSnapCreditBudget();
+
+    FoodPhotoAnalyzerAgent::fake(function (): void {
+        throw new Exception('Analyzer must not run when the credit budget is exhausted');
+    });
+
+    $response = $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()]);
+
+    $response->assertStatus(402)
+        ->assertJsonPath('error', 'usage_limit_exceeded')
+        ->assertJsonPath('tier', 'free')
+        ->assertJsonPath('limit_credits', 0)
+        ->assertJsonStructure(['limit_type', 'tier_label', 'current_credits', 'resets_at', 'resets_in']);
+
+    expect(AnalysisDraft::query()->count())->toBe(0)
+        ->and(AiUsage::query()->count())->toBe(0);
+});
+
+it('returns a real 429 with Retry-After instead of the web redirect when the burst cap is hit', function (): void {
+    config()->set('plate.snap_to_track.burst_caps.default', 1);
+
+    fakeApiSnapAnalysis();
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    $response = $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()]);
+
+    $response->assertStatus(429);
+
+    expect($response->headers->get('Retry-After'))->not->toBeNull()
+        ->and(AnalysisDraft::query()->count())->toBe(1);
+});
+
+it('keys the burst limiter per user rather than per IP', function (): void {
+    config()->set('plate.snap_to_track.burst_caps.default', 1);
+
+    fakeApiSnapAnalysis();
+
+    Sanctum::actingAs($this->user, ['chat:converse']);
+
+    $this->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    $this->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertStatus(429);
+
+    $other = User::factory()->create();
+    Sanctum::actingAs($other, ['chat:converse']);
+
+    $this->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    expect(AnalysisDraft::query()->count())->toBe(2);
+});
+
+it('localizes the analysis using the Accept-Language header over the account locale', function (): void {
+    fakeApiSnapAnalysis();
+
+    $this->user->update(['locale' => 'en']);
+
+    $agent = new FoodPhotoAnalyzerAgent();
+    app()->instance(FoodPhotoAnalyzerAgent::class, $agent);
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->withHeader('Accept-Language', 'mn')
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    expect($agent->instructions())->toContain('Монгол');
+});
+
+it('falls back to the account locale when the requested language is unsupported', function (): void {
+    fakeApiSnapAnalysis();
+
+    $this->user->update(['locale' => 'mn']);
+
+    $agent = new FoodPhotoAnalyzerAgent();
+    app()->instance(FoodPhotoAnalyzerAgent::class, $agent);
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->withHeader('Accept-Language', 'de-DE,de;q=0.9')
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    expect($agent->instructions())->toContain('Монгол');
+});
+
+it('matches a regional Accept-Language tag to its base language', function (): void {
+    fakeApiSnapAnalysis();
+
+    $this->user->update(['locale' => 'en']);
+
+    $agent = new FoodPhotoAnalyzerAgent();
+    app()->instance(FoodPhotoAnalyzerAgent::class, $agent);
+
+    $this->withHeader('Authorization', 'Bearer '.$this->token)
+        ->withHeader('Accept-Language', 'fr-CA,fr;q=0.9')
+        ->postJson(route('api.v2.snap-to-track.analyze'), ['photo' => apiSnapPhotoDataUrl()])
+        ->assertOk();
+
+    expect($agent->instructions())->toContain('Français');
+});

--- a/tests/Feature/Http/Controllers/Api/V2/SnapToTrack/StoreSnapToTrackMealControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V2/SnapToTrack/StoreSnapToTrackMealControllerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AnalysisDraftSource;
+use App\Http\Controllers\Api\V2\SnapToTrack\StoreSnapToTrackMealController;
+use App\Jobs\AggregateUserDayJob;
+use App\Models\AnalysisDraft;
+use App\Models\HealthSyncSample;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+covers(StoreSnapToTrackMealController::class);
+
+/**
+ * @return array{0: string, 1: AnalysisDraft}
+ */
+function apiMobileDraftFor(User $user): array
+{
+    $token = Str::random(64);
+
+    $draft = AnalysisDraft::factory()->claimed($user)->create([
+        'token_hash' => AnalysisDraft::hashToken($token),
+        'source' => AnalysisDraftSource::MobileSnapToTrack,
+    ]);
+
+    return [$token, $draft];
+}
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function apiReviewedMealPayload(array $overrides = []): array
+{
+    return [
+        'items' => [
+            ['name' => 'Grilled chicken', 'portion' => '100g', 'calories' => 165, 'protein' => 31, 'carbs' => 0, 'fat' => 3.6, 'provenance' => 'model'],
+            ['name' => 'Steamed rice', 'calories' => 210, 'protein' => 4, 'carbs' => 45, 'fat' => 0.5, 'provenance' => 'reference'],
+        ],
+        'measured_at' => now()->subHour()->toIso8601String(),
+        'notes' => 'Lunch bowl',
+        ...$overrides,
+    ];
+}
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+
+    Sanctum::actingAs($this->user, ['chat:converse']);
+});
+
+it('requires authentication', function (): void {
+    app()->forgetInstance('auth');
+    auth()->forgetGuards();
+
+    $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => Str::random(64)]), apiReviewedMealPayload())
+        ->assertUnauthorized();
+});
+
+it('logs the reviewed meal as grouped mobile health samples', function (): void {
+    [$token, $draft] = apiMobileDraftFor($this->user);
+
+    $response = $this->postJson(
+        route('api.v2.snap-to-track.meal', ['draft' => $token]),
+        apiReviewedMealPayload(),
+    );
+
+    $response->assertCreated()
+        ->assertJsonStructure(['group_id', 'measured_at', 'totals' => ['calories', 'protein', 'carbs', 'fat']]);
+
+    expect((float) $response->json('totals.calories'))->toBe(375.0)
+        ->and((float) $response->json('totals.protein'))->toBe(35.0)
+        ->and((float) $response->json('totals.carbs'))->toBe(45.0)
+        ->and((float) $response->json('totals.fat'))->toBe(4.1);
+
+    $samples = HealthSyncSample::query()->where('user_id', $this->user->id)->get();
+
+    expect($samples)->toHaveCount(4)
+        ->and($samples->pluck('type_identifier')->sort()->values()->all())
+        ->toBe(['carbohydrates', 'dietaryEnergy', 'protein', 'totalFat'])
+        ->and($samples->firstWhere('type_identifier', 'dietaryEnergy')->value)->toBe(375.0)
+        ->and($samples->pluck('entry_source')->unique()->pluck('value')->all())->toBe(['mobile'])
+        ->and($samples->pluck('group_id')->unique())->toHaveCount(1)
+        ->and($samples->first()->group_id)->toBe($response->json('group_id'))
+        ->and($samples->first()->metadata['snap_to_track']['source'])->toBe('mobile_snap_to_track')
+        ->and($samples->first()->metadata['snap_to_track']['items'])->toHaveCount(2)
+        ->and($draft->refresh()->isConsumed())->toBeTrue()
+        ->and($draft->health_group_id)->toBe($response->json('group_id'));
+});
+
+it('refreshes the daily aggregate for the measured day', function (): void {
+    Queue::fake();
+
+    [$token] = apiMobileDraftFor($this->user);
+
+    $measuredAt = now()->subHour();
+
+    $this->postJson(
+        route('api.v2.snap-to-track.meal', ['draft' => $token]),
+        apiReviewedMealPayload(['measured_at' => $measuredAt->toIso8601String()]),
+    )->assertCreated();
+
+    Queue::assertPushed(
+        AggregateUserDayJob::class,
+        fn (AggregateUserDayJob $job): bool => $job->uniqueId()
+            === $this->user->id.':'.$measuredAt->copy()->utc()->toDateString(),
+    );
+});
+
+it('replays a consumed draft idempotently instead of duplicating the meal', function (): void {
+    [$token] = apiMobileDraftFor($this->user);
+
+    $first = $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => $token]), apiReviewedMealPayload());
+    $first->assertCreated();
+
+    $second = $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => $token]), apiReviewedMealPayload());
+
+    $second->assertOk()
+        ->assertJsonPath('group_id', $first->json('group_id'));
+
+    expect(HealthSyncSample::query()->where('user_id', $this->user->id)->count())->toBe(4);
+});
+
+it('still saves a claimed draft whose restore window has expired', function (): void {
+    $token = Str::random(64);
+
+    AnalysisDraft::factory()->claimed($this->user)->expired()->create([
+        'token_hash' => AnalysisDraft::hashToken($token),
+        'source' => AnalysisDraftSource::MobileSnapToTrack,
+    ]);
+
+    $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => $token]), apiReviewedMealPayload())
+        ->assertCreated();
+
+    expect(HealthSyncSample::query()->where('user_id', $this->user->id)->count())->toBe(4);
+});
+
+it('returns draft_unavailable for an unknown token', function (): void {
+    $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => Str::random(64)]), apiReviewedMealPayload())
+        ->assertNotFound()
+        ->assertJsonPath('error', 'draft_unavailable')
+        ->assertJsonPath('reason', 'invalid');
+
+    expect(HealthSyncSample::query()->count())->toBe(0);
+});
+
+it('returns draft_unavailable for a draft claimed by another user', function (): void {
+    [$token] = apiMobileDraftFor(User::factory()->create());
+
+    $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => $token]), apiReviewedMealPayload())
+        ->assertNotFound()
+        ->assertJsonPath('reason', 'invalid');
+
+    expect(HealthSyncSample::query()->count())->toBe(0);
+});
+
+it('validates the reviewed items', function (array $overrides, string $errorKey): void {
+    [$token] = apiMobileDraftFor($this->user);
+
+    $this->postJson(route('api.v2.snap-to-track.meal', ['draft' => $token]), apiReviewedMealPayload($overrides))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([$errorKey]);
+
+    expect(HealthSyncSample::query()->count())->toBe(0);
+})->with([
+    'no items' => [['items' => []], 'items'],
+    'missing name' => [['items' => [['calories' => 10]]], 'items.0.name'],
+    'negative calories' => [['items' => [['name' => 'Toast', 'calories' => -5]]], 'items.0.calories'],
+    'per-item calories over cap' => [['items' => [['name' => 'Toast', 'calories' => 5001]]], 'items.0.calories'],
+    'bad provenance' => [['items' => [['name' => 'Toast', 'provenance' => 'guess']]], 'items.0.provenance'],
+    'missing measured_at' => [['measured_at' => null], 'measured_at'],
+    'notes too long' => [['notes' => str_repeat('a', 501)], 'notes'],
+]);
+
+it('rejects a meal whose combined macros exceed the caps', function (): void {
+    [$token] = apiMobileDraftFor($this->user);
+
+    $items = array_fill(0, 3, ['name' => 'Cake', 'calories' => 2000, 'protein' => 10, 'carbs' => 100, 'fat' => 20]);
+
+    $this->postJson(
+        route('api.v2.snap-to-track.meal', ['draft' => $token]),
+        apiReviewedMealPayload(['items' => $items]),
+    )
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['items']);
+
+    expect(HealthSyncSample::query()->count())->toBe(0);
+});

--- a/tests/Unit/Utilities/Base64ImageTest.php
+++ b/tests/Unit/Utilities/Base64ImageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Rules\ValidBase64Image;
+use App\Utilities\Base64Image;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
+
+covers(Base64Image::class);
+
+function rawJpegBytes(int $width = 32, int $height = 32): string
+{
+    $file = UploadedFile::fake()->image('meal.jpg', $width, $height);
+
+    return (string) file_get_contents((string) $file->getRealPath());
+}
+
+it('decodes a data url payload and reports the detected mime type', function (): void {
+    $image = Base64Image::decode('data:image/jpeg;base64,'.base64_encode(rawJpegBytes()));
+
+    expect($image)->not->toBeNull()
+        ->and($image->mimeType)->toBe('image/jpeg')
+        ->and($image->byteLength())->toBeGreaterThan(0);
+});
+
+it('decodes a bare base64 payload without a data url prefix', function (): void {
+    $image = Base64Image::decode(base64_encode(rawJpegBytes()));
+
+    expect($image)->not->toBeNull()
+        ->and($image->mimeType)->toBe('image/jpeg');
+});
+
+it('trusts the decoded bytes over a mismatched data url mime type', function (): void {
+    $image = Base64Image::decode('data:image/png;base64,'.base64_encode(rawJpegBytes()));
+
+    expect($image?->mimeType)->toBe('image/jpeg');
+});
+
+it('round-trips the payload back to base64', function (): void {
+    $bytes = rawJpegBytes();
+    $image = Base64Image::decode(base64_encode($bytes));
+
+    expect($image?->base64())->toBe(base64_encode($bytes))
+        ->and($image?->byteLength())->toBe(mb_strlen($bytes, '8bit'));
+});
+
+it('rejects payloads that are not decodable images', function (string $payload): void {
+    expect(Base64Image::decode($payload))->toBeNull();
+})->with([
+    'empty' => [''],
+    'whitespace' => ['   '],
+    'not base64' => ['@@@@@'],
+    'base64 of plain text' => [fn (): string => base64_encode('definitely not an image')],
+    'data url with no payload' => ['data:image/jpeg;base64,'],
+    'data url with no comma' => ['data:image/jpeg;base64'],
+]);
+
+it('passes the validation rule for an image within the size cap', function (): void {
+    $validator = Validator::make(
+        ['photo' => 'data:image/jpeg;base64,'.base64_encode(rawJpegBytes())],
+        ['photo' => [new ValidBase64Image(10240)]],
+    );
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('fails the validation rule when the decoded image exceeds the size cap', function (): void {
+    $validator = Validator::make(
+        ['photo' => 'data:image/jpeg;base64,'.base64_encode(rawJpegBytes(600, 600))],
+        ['photo' => [new ValidBase64Image(1)]],
+    );
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('photo'))->toContain('1 kilobytes');
+});
+
+it('fails the validation rule for a non-image payload', function (): void {
+    $validator = Validator::make(
+        ['photo' => base64_encode('not an image')],
+        ['photo' => [new ValidBase64Image(10240)]],
+    );
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('photo'))->toContain('must be an image');
+});


### PR DESCRIPTION
Adds the backend half of Snap to Track on iOS. The web module is Inertia/session-only and returns 302s, so Sanctum bearer tokens cannot reach it and there was no JSON equivalent in `routes/api.php`. Paired with acara-app/apple-health-sync#53.

## Endpoints

Both `auth:sanctum`, no ability requirement — existing mobile tokens are minted with `chat:converse` only, so gating on a new ability would 403 every already-signed-in user. `POST v2/sync/devices` sets the same precedent.

| | |
|---|---|
| `POST /api/v2/snap-to-track/analyze` | `{photo}` → `{draft_token, expires_at, analysis}` |
| `POST /api/v2/snap-to-track/drafts/{token}/meal` | `{items[], measured_at, notes}` → `{group_id, measured_at, totals}` |

The three existing Actions (`AnalyzeFoodPhotoAction`, `CreateAnalysisDraftAction`, `LogReviewedMealAction`) are reused unchanged; the controllers are thin.

## Base64 instead of multipart

`AnalyzeFoodPhotoAction` already wants base64 and the web controller base64s its upload anyway, while the iOS chat encoder already emits `data:image/jpeg;base64,…`. Accepting base64 directly drops an encode/decode hop on both sides and means zero new upload code on the client.

`Base64Image` re-detects the mime type from the decoded bytes and ignores whatever the data URL prefix claims, so a mismatched prefix cannot smuggle a type through. Payloads must decode to a real JPEG/PNG/WebP/GIF of at most 10240 KB, matching the web rule.

## Seams widened

- `AnalysisDraftSource::MobileSnapToTrack` — keeps web and mobile funnels separable; flows into sample metadata for free via `ReviewedMealData::toHealthLogData()`.
- `HealthEntrySource::Mobile` — deliberately **not** `MobileSync`, which `2026_04_07_194458_relax_health_sync_samples_unique_index_for_medications` singles out for Apple-Health dedup. These meals must not fall under those rules. Column is a plain `string(20)`, so no migration.
- `LogReviewedMealAction` takes a `HealthEntrySource`, defaulting to `Web` so the existing call site is untouched.
- Reviewed-meal validation extracted into a `ValidatesReviewedMeal` trait shared by the web and API requests, so the rules cannot drift.

## Behaviour worth reviewing

- **402 is intentionally uncaught.** `UsageLimitExceededException` renders its own 402 with the payload the client already decodes. The web controller catches it and flashes to session instead.
- **429 is real.** The route is named `api.v2.snap-to-track.analyze` specifically so it does *not* match the `routeIs('snap-to-track.analyze')` guard in `bootstrap/app.php` that turns throttling into a redirect. There's a test pinning this, because it's load-bearing and invisible.
- **Replay is idempotent.** A consumed draft returns the original `group_id` with a 200 rather than erroring, so a retried save cannot duplicate a meal.
- Like web, `expires_at` is not checked on save — an expired but claimed draft still saves.
- `Accept-Language` picks the first *supported* requested language and falls back to the account locale when none match, rather than `getPreferredLanguage`'s "first option on no match".

## Tests

New suites mirror the existing web ones. Notably: a blocked scan asserts `AiUsage::count() === 0`, the burst limit asserts a 429 with `Retry-After` rather than a redirect, and per-user limiter keying is verified via `Sanctum::actingAs`.

**Full suite: 2796 tests / 9409 assertions pass.** Pint and PHPStan clean.
