### PR TITLE
fix(api): rename the snap-to-track photo accessor off Request::image()

### DIFF
--- a/app/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoController.php
+++ b/app/Http/Controllers/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoController.php
@@ -32,7 +32,7 @@ final readonly class AnalyzeSnapToTrackPhotoController
             ModelName::tryFrom(config()->string('plate.food_photo_analyzer.model')),
         );
 
-        $image = $request->image();
+        $image = $request->decodedImage();
 
         ['label' => $language, 'code' => $languageCode] = LanguageUtil::resolve(
             $this->requestedLocale($request) ?? $user->locale,

--- a/app/Http/Requests/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoRequest.php
+++ b/app/Http/Requests/Api/V2/SnapToTrack/AnalyzeSnapToTrackPhotoRequest.php
@@ -31,7 +31,7 @@ final class AnalyzeSnapToTrackPhotoRequest extends FormRequest
         ];
     }
 
-    public function image(): Base64Image
+    public function decodedImage(): Base64Image
     {
         if ($this->decoded instanceof Base64Image) {
             return $this->decoded;


### PR DESCRIPTION
## Problem

`main` is red and the v2 snap-to-track endpoint is dead on arrival.

`laravel/framework 13.23` added `Illuminate\Http\Request::image(string $key): ?Illuminate\Image\Image` (`Http/Concerns/InteractsWithInput.php:251`). `App\Http\Requests\Api\V2\SnapToTrack\AnalyzeSnapToTrackPhotoRequest` declares `image(): Base64Image`, which is now an incompatible override:

```
Pest\Exceptions\FatalException
Declaration of App\Http\Requests\Api\V2\SnapToTrack\AnalyzeSnapToTrackPhotoRequest::image(): App\Utilities\Base64Image
must be compatible with Illuminate\Http\Request::image(string $key): ?Illuminate\Image\Image
```

Because it is a PHP fatal raised at class-load time, it aborts the entire Pest run (not one test) and would 500 `POST /api/v2/snap-to-track/analyze` in production.

## Fix

Rename the accessor to `decodedImage()` and update its single caller. The framework's `image()` reads an uploaded file by key; ours decodes a base64 body field into `App\Utilities\Base64Image` — different jobs, so no reason to sit on the inherited name.

## Verification

Full suite green: `PAO_DISABLE=1 vendor/bin/pest --testsuite=Unit,Feature` → **2738 passed** (9276 assertions). `vendor/bin/pint --dirty` passes.